### PR TITLE
Add feature flag to enable slowlog thresholds

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -285,8 +285,10 @@ function override_elasticpress_feature_activation( bool $is_active, array $setti
 function enable_slowlog_thresholds( array $mapping ) : array {
 	$config = get_config()['modules']['search'];
 	if ( isset( $config['slowlog_thresholds'] ) && (bool) $config['slowlog_thresholds'] ) {
-		$mapping['settings']['index.search.slowlog.threshold.query.info'] = '500ms';
-		$mapping['settings']['index.search.slowlog.threshold.query.warn'] = '2s';
+		$mapping['settings']['index.search.slowlog.threshold.query.info'] = '2s';
+		$mapping['settings']['index.search.slowlog.threshold.query.warn'] = '5s';
+		$mapping['settings']['index.search.slowlog.threshold.fetch.info'] = '2s';
+		$mapping['settings']['index.search.slowlog.threshold.fetch.warn'] = '5s';
 	}
 	return $mapping;
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -52,6 +52,7 @@ function load_elasticpress() {
 	add_filter( 'ep_indexable_post_status', __NAMESPACE__ . '\\get_elasticpress_indexable_post_statuses' );
 	add_filter( 'ep_indexable_post_types', __NAMESPACE__ . '\\get_elasticpress_indexable_post_types' );
 	add_filter( 'ep_feature_active', __NAMESPACE__ . '\\override_elasticpress_feature_activation', 10, 3 );
+	add_filter( 'ep_config_mapping', __NAMESPACE__ . '\\enable_slowlog_thresholds' );
 
 	require_once ROOT_DIR . '/vendor/10up/elasticpress/elasticpress.php';
 
@@ -273,6 +274,21 @@ function override_elasticpress_feature_activation( bool $is_active, array $setti
 	}
 
 	return $features_activated[ $feature->slug ];
+}
+
+/**
+ * Enables the required settings for slowlog queries to be captured.
+ *
+ * @param array $mapping
+ * @return array
+ */
+function enable_slowlog_thresholds( array $mapping ) : array {
+	$config = get_config()['modules']['search'];
+	if ( isset( $config['slowlog_thresholds'] ) && (bool) $config['slowlog_thresholds'] ) {
+		$mapping['settings']['index.search.slowlog.threshold.query.info'] = '500ms';
+		$mapping['settings']['index.search.slowlog.threshold.query.warn'] = '2s';
+	}
+	return $mapping;
 }
 
 /**

--- a/load.php
+++ b/load.php
@@ -1,5 +1,6 @@
 <?php
 
+// phpcs:ignore
 namespace Altis\Enhanced_Search;
 
 use function Altis\register_module;

--- a/load.php
+++ b/load.php
@@ -14,6 +14,7 @@ add_action( 'altis.modules.init', function () {
 	$default_settings = [
 		'enabled' => true,
 		'index-documents' => true,
+		'slowlog_thresholds' => true,
 	];
 	register_module( 'search', __DIR__, 'Search', $default_settings, __NAMESPACE__ . '\\bootstrap' );
 } );


### PR DESCRIPTION
One of our clients has been utilizing ElasticSearch's slow query logs, but there have been issues with the query logs being disabled.

I did some digging into why there were no slow query logs even though they were enabled on the ElasticSearch instance. Enabling the slow query logs is a multi-step process and I suspect one of the required settings was disabled at some point, which disabled the slow query log. When enabling slow query logs in ElasticSearch, we have to both enable query logging in AWS as well as update a setting within each ElasticSearch index we want the slow query log enabled on. I believe this setting is getting reset whenever we run `wp elasticpress index` with the `--setup` flag. Looking at [ElasticPress' code](https://github.com/10up/ElasticPress/blob/2.8.1/includes/mappings/5-2.php#L14-L64), we can see when mappings are submitted, settings are also set. I did some testing and was able to confirm my theory that running an index with the `--setup` flag does indeed remove the ElasticSearch settings needed for the Slow Query log to function as desired.

So where do we go from here? I would recommend we add a filter/function/something utilizing the [`ep_config_mapping`](https://github.com/10up/ElasticPress/blob/2.8.1/classes/class-ep-api.php#L535) filter to add the required settings to keep the slow log functioning as desired.

I can see a few ways of implimenting this. This PR directly enables the slow logs. I can also see us adding a `settings` field to the `search` Altis config where we could directly pass settings that way. I'm open to either/both! Having it this way keeps it simple, while adding the abilty to pass settings could also be nice, but requires specific knowledge.