### PR TITLE
Allow defining EP_INDEX_PREFIX from env

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -39,6 +39,11 @@ function load_elasticpress() {
 		define( 'EP_IS_NETWORK', true );
 	}
 
+	// Set index prefix from env if found. Used for separating test indexes.
+	if ( getenv( 'EP_INDEX_PREFIX' ) && ! defined( 'EP_INDEX_PREFIX' ) ) {
+		define( 'EP_INDEX_PREFIX', getenv( 'EP_INDEX_PREFIX' ) );
+	}
+
 	// Disable being able to use the admin to run a full data sync.
 	if ( ! defined( 'EP_DASHBOARD_SYNC' ) ) {
 		define( 'EP_DASHBOARD_SYNC', false );


### PR DESCRIPTION
This allows us to separate elasticsearch indexes - just as we do with `$table_prefix` this is useful running tests and also in future for on-demand environments eg. for a branch.`