### PR TITLE
Raise error reporting threshold during index command

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -77,7 +77,7 @@ function load_elasticpress() {
 	}
 
 	if ( defined( 'WP_CLI' ) && WP_CLI ) {
-		// Raise error reporting level for the index command as it will generate
+		// Raise error reporting threshold for the index command as it will generate
 		// a benign warning when the index doesn't already exist.
 		WP_CLI::add_hook( 'before_invoke:elasticpress index', function () {
 			error_reporting( E_ERROR );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -78,7 +78,7 @@ function load_elasticpress() {
 
 	if ( defined( 'WP_CLI' ) && WP_CLI ) {
 		// Raise error reporting level for the index command as it will generate
-		// a benign warning when the index doesn't alreaddy exist.
+		// a benign warning when the index doesn't already exist.
 		WP_CLI::add_hook( 'before_invoke:elasticpress index', function () {
 			error_reporting( E_ERROR );
 		} );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -77,6 +77,12 @@ function load_elasticpress() {
 	}
 
 	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		// Raise error reporting level for the index command as it will generate
+		// a benign warning when the index doesn't alreaddy exist.
+		WP_CLI::add_hook( 'before_invoke:elasticpress index', function () {
+			error_reporting( E_ERROR );
+		} );
+		// Index after install.
 		WP_CLI::add_hook( 'after_invoke:core multisite-install', __NAMESPACE__ . '\\setup_elasticpress_on_install' );
 	}
 


### PR DESCRIPTION
This ensures the benign warning doesn't show during indexing when the index does not yet exist.