### PR TITLE
Detect if ELASTICSEARCH_HOST is empty

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -28,7 +28,7 @@ function bootstrap() {
  * Load and configure Elasticpress.
  */
 function load_elasticpress() {
-	if ( ! defined( 'ELASTICSEARCH_HOST' ) ) {
+	if ( ! defined( 'ELASTICSEARCH_HOST' ) || ! ELASTICSEARCH_HOST ) {
 		return;
 	}
 	if ( ! defined( 'EP_HOST' ) ) {


### PR DESCRIPTION
This will prevent the module from bootstrapping if `ELASTICSEARCH_HOST` is empty, such as in the case no ElasticSearch infrastructure has been provisioned for an environment.