### PR TITLE
Add config docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ The Search module provides a mirrored index of all CMS content that is optimized
 
 The default Search index and related functionality is provided by the [ElasticPress plugin](https://github.com/10up/ElasticPress).
 
-If you do not wish to use the search it can be deactivated via your config:
+If you do not wish to use the search module it can be deactivated via your config:
 
 ```json
 {

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,22 @@ The Search module provides a mirrored index of all CMS content that is optimized
 
 The default Search index and related functionality is provided by the [ElasticPress plugin](https://github.com/10up/ElasticPress).
 
+If you do not wish to use the search it can be deactivated via your config:
+
+```json
+{
+	"extra": {
+		"altis": {
+			"modules": {
+				"search": {
+					"enabled": false
+				}
+			}
+		}
+	}
+}
+```
+
 Content that is indexed in the search index by default:
 
 - Posts


### PR DESCRIPTION
We hadn't documented how to switch this one off so there was some confusion over the module key to use as highlighted in #48 

In future we should rename this repo and the composer package.