### PR TITLE
Support Austrian German in Analyzer Language

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -397,6 +397,7 @@ function elasticpress_analyzer_language( string $language, string $filter ) : st
 		'fr_ca'          => 'french',
 		'fr_fr'          => 'french',
 		'gl_es'          => 'galician',
+		'de_at'          => 'german',
 		'de_ch'          => 'german',
 		'de_ch_informal' => 'german',
 		'de_de'          => 'german',


### PR DESCRIPTION
Adds Austrian German to the mapping of analyzer languages.