### PR TITLE
Provide full list of types and stati to ElasticPress

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -272,7 +272,7 @@ function run_elasticpress_synced_healthcheck() {
  * @return array
  */
 function get_elasticpress_indexable_post_statuses( array $statuses ) : array {
-	return [ 'any' ];
+	return get_post_stati();
 }
 
 /**
@@ -286,7 +286,7 @@ function get_elasticpress_indexable_post_statuses( array $statuses ) : array {
  * @return array
  */
 function get_elasticpress_indexable_post_types( array $types ) : array {
-	return [ 'any' ];
+	return get_post_types();
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -282,7 +282,7 @@ function get_elasticpress_indexable_post_statuses( array $statuses ) : array {
  * we want to index all content as we are using ElasticPress
  * in the WordPress admin too.
  *
- * @param array $statuses
+ * @param array $types
  * @return array
  */
 function get_elasticpress_indexable_post_types( array $types ) : array {


### PR DESCRIPTION
Previsouly we were returning `any` for the allowed post types and post stati for ElasticPress. This works when we index a full site, because the value `any` is passed to `WP_Query`, which is a valid post type argument.

However, in post updating, when `EP_Sync_Manager::action_sync_on_update` is called, the code does somethign more like `in_array( $post_status, $allowed_stati )`, to which `any` does not match. ElasticPress needs all the status strings, the `any` special case is not suficient.