### PR TITLE
Add multilingual analyzers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@
 
 # Enhanced Search
 
-A better default search experience for Altis. Building off the [ElasticPress](https://github.com/10up/ElasticPress) plugin.
+A better default search experience for Altis. Building off the [ElasticPress](https://github.com/10up/ElasticPress) plugin and the [WordPress.com ElasticSearch library](https://github.com/Automattic/wpes-lib).

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 The Search module provides a mirrored index of all CMS content that is optimized for search relevance, speed and accuracy. The Search module overrides the default search functionality to query the specialized search index in place of a standard MySQL query. This means all default search operations using the CMS search APIs for posts such as `WP_Query`, `get_posts`, `get_search_form()` and the REST API search endpoints will transparently make use of the search index.
 
-The default Search index and related functionality is provided by the [ElasticPress plugin](https://github.com/10up/ElasticPress).
+The default Search index and related functionality is provided by the [ElasticPress plugin](https://github.com/10up/ElasticPress) and the multilingual support is derived from [the WordPress.com ElasticSearch library](https://github.com/Automattic/wpes-lib).
 
 If you do not wish to use the search module it can be deactivated via your config:
 
@@ -65,7 +65,7 @@ The following options can be enabled/disabled via the search configuration.
 ### Related Posts
 To find related posts leveraging Elastic Search use the `ep_find_related()` function. The function requires a single parameter ( `$post_id` ) with another optional parameter ( `$return` ). The `$post_id` will be used to find the posts that are related to it, with `$return` specifying the number of related posts to return, which defaults to 5.
 
-If an out of the box solution is desired, a widget `ElasticPress - Related Posts` is created that can be added to your site's sidebar. In order for the widget to work correctly it needs to be added to the sidebar which will be displayed for a single post. 
+If an out of the box solution is desired, a widget `ElasticPress - Related Posts` is created that can be added to your site's sidebar. In order for the widget to work correctly it needs to be added to the sidebar which will be displayed for a single post.
 
 ### Facets
 Facets are a feature in ElasticPress which add control to filter content by one or more taxonomies. A widget can be added so when viewing a content list (archive), the taxonomy and all of its terms will be displayed. This will allow a vistors to further filter content.
@@ -75,4 +75,4 @@ Depending on the configuration specified for `facets`, if the `match-type` prope
 ### Auto Suggest
 The default auto suggest functionality has been modified but does not effect the default WP search form template.
 
-In addition to the default auto suggest endpoint, an additional endpoint was added (`/autosuggest/`). This endpoint accepts as json object to modify the parameters that are forwarded to ElasticPress for suggesting posts.  
+In addition to the default auto suggest endpoint, an additional endpoint was added (`/autosuggest/`). This endpoint accepts as json object to modify the parameters that are forwarded to ElasticPress for suggesting posts.

--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -7,6 +7,7 @@ The languages supported are as follows:
 - Arabic
 - Armenian
 - Basque
+- Bengali
 - Brazilian
 - Bulgarian
 - Catalan
@@ -20,16 +21,19 @@ The languages supported are as follows:
 - Galician
 - German
 - Greek
+- Hebrew
 - Hindi
 - Hungarian
 - Indonesian
 - Italian
+- Irish
 - Japanese
 - Korean
 - Latvian
 - Lithuanian
 - Norwegian
 - Persian
+- Polish
 - Portuguese
 - Romanian
 - Russian
@@ -38,3 +42,4 @@ The languages supported are as follows:
 - Swedish
 - Turkish
 - Thai
+- Ukrainian

--- a/inc/analyzers.json
+++ b/inc/analyzers.json
@@ -1,0 +1,768 @@
+{
+	"filter": {
+		"possessive_filter": {
+			"type": "stemmer",
+			"name": "possessive_english"
+		},
+		"ar_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_arabic_"
+			]
+		},
+		"bg_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_bulgarian_"
+			]
+		},
+		"ca_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_catalan_"
+			]
+		},
+		"ckb_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_sorani_"
+			]
+		},
+		"ckb_stem_filter": {
+			"type": "stemmer",
+			"name": "sorani"
+		},
+		"cs_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_czech_"
+			]
+		},
+		"da_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_danish_"
+			]
+		},
+		"de_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_german_"
+			]
+		},
+		"de_stem_filter": {
+			"type": "stemmer",
+			"name": "minimal_german"
+		},
+		"el_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_greek_"
+			]
+		},
+		"en_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_english_"
+			]
+		},
+		"en_stem_filter": {
+			"type": "stemmer",
+			"name": "minimal_english"
+		},
+		"es_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_spanish_"
+			]
+		},
+		"es_stem_filter": {
+			"type": "stemmer",
+			"name": "light_spanish"
+		},
+		"eu_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_basque_"
+			]
+		},
+		"fa_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_persian_"
+			]
+		},
+		"fi_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_finnish_"
+			]
+		},
+		"fi_stem_filter": {
+			"type": "stemmer",
+			"name": "light_finish"
+		},
+		"fr_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_french_"
+			]
+		},
+		"fr_stem_filter": {
+			"type": "stemmer",
+			"name": "minimal_french"
+		},
+		"gl_stop_filter": {
+			"type": "stop",
+			"stopwords": ["_galician_"]
+		},
+		"gl_stem_filter": {
+			"type": "stemmer",
+			"name": "minimal_galician"
+		},
+		"greek_lowercase_filter": {
+			"type": "lowercase",
+			"language": "greek"
+		},
+		"he_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"אבל",
+				"או",
+				"אולי",
+				"אותה",
+				"אותה",
+				"אותו",
+				"אותו",
+				"אותו",
+				"אותי",
+				"אותך",
+				"אותם",
+				"אותן",
+				"אותנו",
+				"אז",
+				"אחר",
+				"אחר",
+				"אחרות",
+				"אחרי",
+				"אחרי",
+				"אחרי",
+				"אחרים",
+				"אחרת",
+				"אי",
+				"איזה",
+				"איך",
+				"אין",
+				"אין",
+				"איפה",
+				"איתה",
+				"איתו",
+				"איתי",
+				"איתך",
+				"איתכם",
+				"איתכן",
+				"איתם",
+				"איתן",
+				"איתנו",
+				"אך",
+				"אך",
+				"אל",
+				"אל",
+				"אלה",
+				"אלה",
+				"אלו",
+				"אלו",
+				"אם",
+				"אם",
+				"אנחנו",
+				"אני",
+				"אס",
+				"אף",
+				"אצל",
+				"אשר",
+				"אשר",
+				"את",
+				"את",
+				"אתה",
+				"אתכם",
+				"אתכן",
+				"אתם",
+				"אתן",
+				"באמצע",
+				"באמצעות",
+				"בגלל",
+				"בין",
+				"בלי",
+				"בלי",
+				"במידה",
+				"ברם",
+				"בשביל",
+				"בתוך",
+				"גם",
+				"דרך",
+				"הוא",
+				"היא",
+				"היה",
+				"היכן",
+				"היתה",
+				"היתי",
+				"הם",
+				"הן",
+				"הנה",
+				"הרי",
+				"ואילו",
+				"ואת",
+				"זאת",
+				"זה",
+				"זה",
+				"זות",
+				"יהיה",
+				"יוכל",
+				"יוכלו",
+				"יותר",
+				"יכול",
+				"יכולה",
+				"יכולות",
+				"יכולים",
+				"יכל",
+				"יכלה",
+				"יכלו",
+				"יש",
+				"כאן",
+				"כאשר",
+				"כולם",
+				"כולן",
+				"כזה",
+				"כי",
+				"כיצד",
+				"כך",
+				"ככה",
+				"כל",
+				"כלל",
+				"כמו",
+				"כמו",
+				"כן",
+				"כן",
+				"כפי",
+				"כש",
+				"לא",
+				"לאו",
+				"לאן",
+				"לבין",
+				"לה",
+				"להיות",
+				"להם",
+				"להן",
+				"לו",
+				"לי",
+				"לכם",
+				"לכן",
+				"לכן",
+				"למה",
+				"למטה",
+				"למעלה",
+				"למרות",
+				"למרות",
+				"לנו",
+				"לעבר",
+				"לעיכן",
+				"לפיכך",
+				"לפני",
+				"לפני",
+				"מאד",
+				"מאחורי",
+				"מאין",
+				"מאיפה",
+				"מבלי",
+				"מבעד",
+				"מדוע",
+				"מדי",
+				"מה",
+				"מהיכן",
+				"מול",
+				"מחוץ",
+				"מי",
+				"מכאן",
+				"מכיוון",
+				"מלבד",
+				"מן",
+				"מנין",
+				"מסוגל",
+				"מעט",
+				"מעטים",
+				"מעל",
+				"מעל",
+				"מצד",
+				"מתחת",
+				"מתחת",
+				"מתי",
+				"נגד",
+				"נגר",
+				"נו",
+				"עד",
+				"עד",
+				"עז",
+				"על",
+				"על",
+				"עלי",
+				"עליה",
+				"עליהם",
+				"עליהן",
+				"עליו",
+				"עליך",
+				"עליכם",
+				"עלינו",
+				"עם",
+				"עם",
+				"עצמה",
+				"עצמהם",
+				"עצמהן",
+				"עצמו",
+				"עצמי",
+				"עצמם",
+				"עצמן",
+				"עצמנו",
+				"פה",
+				"רק",
+				"רק",
+				"שוב",
+				"שוב",
+				"של",
+				"שלה",
+				"שלהם",
+				"שלהן",
+				"שלו",
+				"שלי",
+				"שלך",
+				"שלכם",
+				"שלכן",
+				"שלנו",
+				"שם",
+				"תהיה",
+				"תחת"
+			]
+		},
+		"hi_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_hindi_"
+			]
+		},
+		"hu_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_hungarian_"
+			]
+		},
+		"hu_stem_filter": {
+			"type": "stemmer",
+			"name": "light_hungarian"
+		},
+		"hy_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_armenian_"
+			]
+		},
+		"id_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_indonesian_"
+			]
+		},
+		"it_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_italian_"
+			]
+		},
+		"it_stem_filter": {
+			"type": "stemmer",
+			"name": "light_italian"
+		},
+		"ja_pos_filter": {
+			"type": "kuromoji_part_of_speech",
+			"stoptags": [
+				"助詞-格助詞-一般",
+				"助詞-終助詞"
+			]
+		},
+		"nl_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_dutch_"
+			]
+		},
+		"no_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_norwegian_"
+			]
+		},
+		"pt_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_portuguese_"
+			]
+		},
+		"pt_stem_filter": {
+			"type": "stemmer",
+			"name": "minimal_portuguese"
+		},
+		"ro_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_romanian_"
+			]
+		},
+		"ru_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_russian_"
+			]
+		},
+		"ru_stem_filter": {
+			"type": "stemmer",
+			"name": "light_russian"
+		},
+		"sv_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_swedish_"
+			]
+		},
+		"sv_stem_filter": {
+			"type": "stemmer",
+			"name": "light_swedish"
+		},
+		"tr_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_turkish_"
+			]
+		}
+	},
+	"char_filter": {
+		"de_char_filter": {
+			"type": "mapping",
+			"mappings": [
+				"ß=>ss",
+				"Ä=>ae",
+				"ä=>ae",
+				"Ö=>oe",
+				"ö=>oe",
+				"Ü=>ue",
+				"ü=>ue",
+				"ph=>f"
+			]
+		}
+	},
+	"analyzer": {
+		"ar_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"ar_stop_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"bg_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"bg_stop_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"ca_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"ca_stop_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"ckb_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"ckb_stop_filter",
+				"ckb_stem_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"cs_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"cs_stop_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"da_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"da_stop_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"de_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"de_stop_filter",
+				"de_stem_filter",
+				"icu_folding"
+			],
+			"char_filter": [
+				"de_char_filter"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"el_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"el_stop_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"en_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"en_stop_filter",
+				"possessive_filter",
+				"en_stem_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"es_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"es_stop_filter",
+				"es_stem_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"eu_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"eu_stop_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"fa_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"fa_stop_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"fi_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"fi_stop_filter",
+				"fi_stem_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"fr_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"elision",
+				"fr_stop_filter",
+				"fr_stem_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"he_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"he_stop_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"hi_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"hi_stop_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"hu_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"hu_stop_filter",
+				"hu_stem_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"hy_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"hy_stop_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"id_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"id_stop_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"it_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"it_stop_filter",
+				"it_stem_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"ja_analyzer": {
+			"type": "custom",
+			"filter": [
+				"kuromoji_baseform",
+				"ja_pos_filter",
+				"icu_normalizer",
+				"icu_folding",
+				"greek_lowercase_filter",
+				"cjk_width"
+			],
+			"tokenizer": "kuromoji_tokenizer"
+		},
+		"ko_analyzer": {
+			"type": "cjk",
+			"filter": []
+		},
+		"nl_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"nl_stop_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"no_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"no_stop_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"pl_analyzer": {
+			"type": "polish"
+		},
+		"pt_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"pt_stop_filter",
+				"pt_stem_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"ro_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"ro_stop_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"ru_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"ru_stop_filter",
+				"ru_stem_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"sv_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"sv_stop_filter",
+				"sv_stem_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"tr_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"tr_stop_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"ua_analyzer": {
+			"type": "ukrainian"
+		},
+		"zh_analyzer": {
+			"type": "smartcn"
+		},
+		"lowercase_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"icu_folding"
+			],
+			"tokenizer": "keyword"
+		},
+		"default_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		}
+	},
+	"tokenizer": {
+		"kuromoji": {
+			"type": "kuromoji_tokenizer",
+			"mode": "search"
+		}
+	}
+}

--- a/inc/analyzers.json
+++ b/inc/analyzers.json
@@ -10,17 +10,61 @@
 				"_arabic_"
 			]
 		},
+		"ar_stem_filter": {
+			"type": "stemmer",
+			"name": "arabic"
+		},
 		"bg_stop_filter": {
 			"type": "stop",
 			"stopwords": [
 				"_bulgarian_"
 			]
 		},
+		"bg_stem_filter": {
+			"type": "stemmer",
+			"name": "bulgarian"
+		},
+		"bn_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_bengali_"
+			]
+		},
+		"bn_stem_filter": {
+			"type": "stemmer",
+			"name": "light_bengali"
+		},
+		"br_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_brazilian_"
+			]
+		},
+		"br_stem_filter": {
+			"type": "stemmer",
+			"name": "brazilian"
+		},
 		"ca_stop_filter": {
 			"type": "stop",
 			"stopwords": [
 				"_catalan_"
 			]
+		},
+		"ca_elision_filter": {
+			"type": "elision",
+			"articles": [
+				"d",
+				"l",
+				"m",
+				"n",
+				"s",
+				"t"
+			],
+			"articles_case": true
+		},
+		"ca_stem_filter": {
+			"type": "stemmer",
+			"name": "catalan"
 		},
 		"ckb_stop_filter": {
 			"type": "stop",
@@ -43,6 +87,10 @@
 			"stopwords": [
 				"_danish_"
 			]
+		},
+		"da_stem_filter": {
+			"type": "stemmer",
+			"name": "danish"
 		},
 		"de_stop_filter": {
 			"type": "stop",
@@ -112,9 +160,48 @@
 			"type": "stemmer",
 			"name": "minimal_french"
 		},
+		"fr_elision_filter": {
+			"type": "elision",
+			"articles_case": true,
+			"articles": [
+				"l",
+				"m",
+				"t",
+				"qu",
+				"n",
+				"s",
+				"j",
+				"d",
+				"c",
+				"jusqu",
+				"quoiqu",
+				"lorsqu",
+				"puisqu"
+			]
+		},
+		"ga_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_irish_"
+			]
+		},
+		"ga_stem_filter": {
+			"type": "stemmer",
+			"name": "_irish_"
+		},
+		"ga_elision_filter": {
+			"type": "elision",
+			"articles": [
+				"h",
+				"n",
+				"t"
+			]
+		},
 		"gl_stop_filter": {
 			"type": "stop",
-			"stopwords": ["_galician_"]
+			"stopwords": [
+				"_galician_"
+			]
 		},
 		"gl_stem_filter": {
 			"type": "stemmer",
@@ -364,6 +451,10 @@
 				"_armenian_"
 			]
 		},
+		"hy_stem_filter": {
+			"type": "stemmer",
+			"name": "armenian"
+		},
 		"id_stop_filter": {
 			"type": "stop",
 			"stopwords": [
@@ -380,6 +471,33 @@
 			"type": "stemmer",
 			"name": "light_italian"
 		},
+		"it_elision_filter": {
+			"type": "elision",
+			"articles": [
+				"c",
+				"l",
+				"all",
+				"dall",
+				"dell",
+				"nell",
+				"sull",
+				"coll",
+				"pell",
+				"gl",
+				"agl",
+				"dagl",
+				"degl",
+				"negl",
+				"sugl",
+				"un",
+				"m",
+				"t",
+				"s",
+				"v",
+				"d"
+			],
+			"articles_case": true
+		},
 		"ja_pos_filter": {
 			"type": "kuromoji_part_of_speech",
 			"stoptags": [
@@ -393,11 +511,32 @@
 				"_dutch_"
 			]
 		},
+		"nl_stem_filter": {
+			"type": "stemmer",
+			"name": "dutch_kp"
+		},
+		"nl_stem_override_filter": {
+			"type": "stemmer_override",
+			"rules": [
+				"fiets=>fiets",
+				"bromfiets=>bromfiets",
+				"ei=>eier",
+				"kind=>kinder"
+			]
+		},
 		"no_stop_filter": {
 			"type": "stop",
 			"stopwords": [
 				"_norwegian_"
 			]
+		},
+		"nb_stem_filter": {
+			"type": "stemmer",
+			"name": "light_norwegian"
+		},
+		"nn_stem_filter": {
+			"type": "stemmer",
+			"name": "light_nynorsk"
 		},
 		"pt_stop_filter": {
 			"type": "stop",
@@ -440,6 +579,14 @@
 			"stopwords": [
 				"_turkish_"
 			]
+		},
+		"tr_lowercase_filter": {
+			"type": "lowercase",
+			"language": "turkish"
+		},
+		"tr_stem_filter": {
+			"type": "stemmer",
+			"language": "turkish"
 		}
 	},
 	"char_filter": {
@@ -455,6 +602,12 @@
 				"ü=>ue",
 				"ph=>f"
 			]
+		},
+		"zero_width_spaces": {
+			"type": "mapping",
+			"mappings": [
+				"\\u200C=> "
+			]
 		}
 	},
 	"analyzer": {
@@ -463,6 +616,7 @@
 			"filter": [
 				"icu_normalizer",
 				"ar_stop_filter",
+				"arabic_normalization",
 				"icu_folding"
 			],
 			"tokenizer": "icu_tokenizer"
@@ -476,9 +630,32 @@
 			],
 			"tokenizer": "icu_tokenizer"
 		},
+		"bn_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"indic_normalization",
+				"bengali_normalization",
+				"bn_stop_filter",
+				"bn_stem_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"br_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"br_stop_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
 		"ca_analyzer": {
 			"type": "custom",
 			"filter": [
+				"ca_elision_filter",
+				"lowercase",
 				"icu_normalizer",
 				"ca_stop_filter",
 				"icu_folding"
@@ -489,8 +666,8 @@
 			"type": "custom",
 			"filter": [
 				"icu_normalizer",
+				"sorani_normalization",
 				"ckb_stop_filter",
-				"ckb_stem_filter",
 				"icu_folding"
 			],
 			"tokenizer": "icu_tokenizer"
@@ -518,6 +695,7 @@
 			"filter": [
 				"icu_normalizer",
 				"de_stop_filter",
+				"german_normalization",
 				"de_stem_filter",
 				"icu_folding"
 			],
@@ -530,6 +708,7 @@
 			"type": "custom",
 			"filter": [
 				"icu_normalizer",
+				"greek_lowercase_filter",
 				"el_stop_filter",
 				"icu_folding"
 			],
@@ -569,8 +748,13 @@
 			"type": "custom",
 			"filter": [
 				"icu_normalizer",
+				"arabic_normalization",
+				"persian_normalization",
 				"fa_stop_filter",
 				"icu_folding"
+			],
+			"char_filter": [
+				"zero_width_spaces"
 			],
 			"tokenizer": "icu_tokenizer"
 		},
@@ -588,9 +772,19 @@
 			"type": "custom",
 			"filter": [
 				"icu_normalizer",
-				"elision",
+				"fr_elision_filter",
 				"fr_stop_filter",
 				"fr_stem_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"ga_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"ga_elision_filter",
+				"ga_stop_filter",
 				"icu_folding"
 			],
 			"tokenizer": "icu_tokenizer"
@@ -608,6 +802,8 @@
 			"type": "custom",
 			"filter": [
 				"icu_normalizer",
+				"indic_normalization",
+				"hindi_normalization",
 				"hi_stop_filter",
 				"icu_folding"
 			],
@@ -645,6 +841,7 @@
 			"type": "custom",
 			"filter": [
 				"icu_normalizer",
+				"it_elision_filter",
 				"it_stop_filter",
 				"it_stem_filter",
 				"icu_folding"
@@ -672,15 +869,28 @@
 			"filter": [
 				"icu_normalizer",
 				"nl_stop_filter",
+				"nl_stem_override_filter",
+				"nl_stem_filter",
 				"icu_folding"
 			],
 			"tokenizer": "icu_tokenizer"
 		},
-		"no_analyzer": {
+		"nb_analyzer": {
 			"type": "custom",
 			"filter": [
 				"icu_normalizer",
 				"no_stop_filter",
+				"nb_stem_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"nn_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"no_stop_filter",
+				"nn_stem_filter",
 				"icu_folding"
 			],
 			"tokenizer": "icu_tokenizer"
@@ -727,10 +937,15 @@
 			],
 			"tokenizer": "icu_tokenizer"
 		},
+		"th_analyzer": {
+			"type": "thai"
+		},
 		"tr_analyzer": {
 			"type": "custom",
 			"filter": [
 				"icu_normalizer",
+				"apostrophe",
+				"tr_lowercase_filter",
 				"tr_stop_filter",
 				"icu_folding"
 			],

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -89,7 +89,7 @@ function load_elasticpress() {
 		// Raise error reporting threshold for the index command as it will generate
 		// a benign warning when the index doesn't already exist.
 		WP_CLI::add_hook( 'before_invoke:elasticpress index', function () {
-			error_reporting( E_ALL );
+			error_reporting( E_ERROR );
 		} );
 		// Index after install.
 		WP_CLI::add_hook( 'after_invoke:core multisite-install', __NAMESPACE__ . '\\setup_elasticpress_on_install' );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -395,10 +395,11 @@ function elasticpress_analyzer_language() : string {
 		'ar'             => 'ar', // arabic.
 		'hy'             => 'hy', // armenian.
 		'eu'             => 'eu', // basque.
-		'pt_br'          => 'pt', // brazilian portuguese.
+		'pt_br'          => 'br', // brazilian portuguese.
 		'bg_bg'          => 'bg', // bulgarian.
+		'bn_bd'          => 'bn', // bengali.
 		'ca'             => 'ca', // catalan.
-		'cs_cz'          => 'cs', // czeh.
+		'cs_cz'          => 'cs', // czech.
 		'da_dk'          => 'da', // danish.
 		'nl_be'          => 'nl', // dutch.
 		'nl_nl'          => 'nl',
@@ -413,6 +414,7 @@ function elasticpress_analyzer_language() : string {
 		'fr_be'          => 'fr', // french.
 		'fr_ca'          => 'fr',
 		'fr_fr'          => 'fr',
+		'ga'             => 'ga', // irish.
 		'gl_es'          => 'gl', // galician.
 		'de_at'          => 'de', // german.
 		'de_ch'          => 'de',
@@ -426,8 +428,8 @@ function elasticpress_analyzer_language() : string {
 		'it_it'          => 'it', // italian.
 		'lv'             => 'lv', // latvian.
 		'lt_lt'          => 'lt', // lithuanian.
-		'nb_no'          => 'no', // norwegian.
-		'nn_no'          => 'no',
+		'nb_no'          => 'nb', // norwegian bokmål.
+		'nn_no'          => 'nn', // norwegian nynorsk.
 		'fa_ir'          => 'fa', // persian.
 		'pl_pl'          => 'pl', // polish.
 		'pt_pt'          => 'pt', // portuguese.
@@ -516,7 +518,7 @@ function elasticpress_mapping( array $mapping ) : array {
 	$mapping['settings']['analysis']['analyzer']['shingle_analyzer'] = [
 		'type' => 'custom',
 		'tokenizer' => 'icu_tokenizer',
-		'filter' => [ 'icu_normalizer', 'icu_folding', 'lowercase', 'shingle_filter' ],
+		'filter' => [ 'icu_normalizer', 'icu_folding', 'shingle_filter' ],
 	];
 
 	// Get analyzer language.
@@ -529,10 +531,6 @@ function elasticpress_mapping( array $mapping ) : array {
 			$mapping['settings']['analysis']['analyzer']['default']['char_filter'] ?? [],
 			[ 'html_strip' ]
 		);
-		// If the last filter was icu_folding then add lowercase filter.
-		if ( end( $mapping['settings']['analysis']['analyzer']['default']['filter'] ) === 'icu_folding' ) {
-			$mapping['settings']['analysis']['analyzer']['default']['filter'][] = 'lowercase';
-		}
 	}
 
 	// Remove deprecated _all parameter.


### PR DESCRIPTION
This adds proper support for unicode characters as well as making use of the builr in stemmers and stop words for all supported languages.

Notable additions are:

- smartcn analyser for chinese languages
- proper use of kuromoji plugin with basic stop tags and lowercasing for roman characters
- ukrainian support
- polish support
- irish support
- brazilian portuguese support
- thai support
- bengali support

This update also ensure the post title is analysed using the site appropriate language and removes a deprecated feature using `_all` as a mapping field. This was unused.

Related https://github.com/humanmade/platform-dev/issues/373