### PR TITLE
Rename package to altis/search

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "altis/enhanced-search",
+	"name": "altis/search",
 	"description": "Enhanced Search module for Altis",
 	"type": "library",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
There has been a discrepancy between the registered module name and the package name since v1 that has caused some confusion. This will rectify that moving forward.

The package altis/enhanced-search will remain available on packagist but will not receive any updates.

Fixes #48 