### PR TITLE
ElasticSearch user dictionary support

### DIFF
--- a/assets/packages.css
+++ b/assets/packages.css
@@ -1,0 +1,11 @@
+/**
+ * Elasticsearch Service Packages UI styles.
+ */
+.columns { display: flex; flex-wrap: wrap; }
+.column { flex: 1 1 300px; width: 300px; margin-right: 20px; }
+.column textarea { width: 100%; }
+.column pre { background: #fff; border: 1px solid #152a4e; padding: 10px; overflow: auto; }
+.column ul li { margin-left: 20px; list-style: disc; }
+.es-package-status { float: right; text-transform: uppercase; padding: 2px 5px; font-size: 65%; border-radius: 3px; background: #152a4e; color: #fff; }
+.es-package-status--active { background-color: #3FCF8E; color: #000; }
+.es-package-status[class*="error"] { background-color: #ED7B9D; color: #152a4e; }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
 	},
 	"autoload" : {
 		"files": [
-			"inc/namespace.php"
+			"inc/namespace.php",
+			"inc/packages/namespace.php"
 		]
 	},
 	"extra": {

--- a/inc/analyzers.json
+++ b/inc/analyzers.json
@@ -10,17 +10,61 @@
 				"_arabic_"
 			]
 		},
+		"ar_stem_filter": {
+			"type": "stemmer",
+			"name": "arabic"
+		},
 		"bg_stop_filter": {
 			"type": "stop",
 			"stopwords": [
 				"_bulgarian_"
 			]
 		},
+		"bg_stem_filter": {
+			"type": "stemmer",
+			"name": "bulgarian"
+		},
+		"bn_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_bengali_"
+			]
+		},
+		"bn_stem_filter": {
+			"type": "stemmer",
+			"name": "light_bengali"
+		},
+		"br_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_brazilian_"
+			]
+		},
+		"br_stem_filter": {
+			"type": "stemmer",
+			"name": "brazilian"
+		},
 		"ca_stop_filter": {
 			"type": "stop",
 			"stopwords": [
 				"_catalan_"
 			]
+		},
+		"ca_elision_filter": {
+			"type": "elision",
+			"articles": [
+				"d",
+				"l",
+				"m",
+				"n",
+				"s",
+				"t"
+			],
+			"articles_case": true
+		},
+		"ca_stem_filter": {
+			"type": "stemmer",
+			"name": "catalan"
 		},
 		"ckb_stop_filter": {
 			"type": "stop",
@@ -43,6 +87,10 @@
 			"stopwords": [
 				"_danish_"
 			]
+		},
+		"da_stem_filter": {
+			"type": "stemmer",
+			"name": "danish"
 		},
 		"de_stop_filter": {
 			"type": "stop",
@@ -112,9 +160,48 @@
 			"type": "stemmer",
 			"name": "minimal_french"
 		},
+		"fr_elision_filter": {
+			"type": "elision",
+			"articles_case": true,
+			"articles": [
+				"l",
+				"m",
+				"t",
+				"qu",
+				"n",
+				"s",
+				"j",
+				"d",
+				"c",
+				"jusqu",
+				"quoiqu",
+				"lorsqu",
+				"puisqu"
+			]
+		},
+		"ga_stop_filter": {
+			"type": "stop",
+			"stopwords": [
+				"_irish_"
+			]
+		},
+		"ga_stem_filter": {
+			"type": "stemmer",
+			"name": "_irish_"
+		},
+		"ga_elision_filter": {
+			"type": "elision",
+			"articles": [
+				"h",
+				"n",
+				"t"
+			]
+		},
 		"gl_stop_filter": {
 			"type": "stop",
-			"stopwords": ["_galician_"]
+			"stopwords": [
+				"_galician_"
+			]
 		},
 		"gl_stem_filter": {
 			"type": "stemmer",
@@ -364,6 +451,10 @@
 				"_armenian_"
 			]
 		},
+		"hy_stem_filter": {
+			"type": "stemmer",
+			"name": "armenian"
+		},
 		"id_stop_filter": {
 			"type": "stop",
 			"stopwords": [
@@ -380,6 +471,33 @@
 			"type": "stemmer",
 			"name": "light_italian"
 		},
+		"it_elision_filter": {
+			"type": "elision",
+			"articles": [
+				"c",
+				"l",
+				"all",
+				"dall",
+				"dell",
+				"nell",
+				"sull",
+				"coll",
+				"pell",
+				"gl",
+				"agl",
+				"dagl",
+				"degl",
+				"negl",
+				"sugl",
+				"un",
+				"m",
+				"t",
+				"s",
+				"v",
+				"d"
+			],
+			"articles_case": true
+		},
 		"ja_pos_filter": {
 			"type": "kuromoji_part_of_speech",
 			"stoptags": [
@@ -393,11 +511,32 @@
 				"_dutch_"
 			]
 		},
+		"nl_stem_filter": {
+			"type": "stemmer",
+			"name": "dutch_kp"
+		},
+		"nl_stem_override_filter": {
+			"type": "stemmer_override",
+			"rules": [
+				"fiets=>fiets",
+				"bromfiets=>bromfiets",
+				"ei=>eier",
+				"kind=>kinder"
+			]
+		},
 		"no_stop_filter": {
 			"type": "stop",
 			"stopwords": [
 				"_norwegian_"
 			]
+		},
+		"nb_stem_filter": {
+			"type": "stemmer",
+			"name": "light_norwegian"
+		},
+		"nn_stem_filter": {
+			"type": "stemmer",
+			"name": "light_nynorsk"
 		},
 		"pt_stop_filter": {
 			"type": "stop",
@@ -440,6 +579,14 @@
 			"stopwords": [
 				"_turkish_"
 			]
+		},
+		"tr_lowercase_filter": {
+			"type": "lowercase",
+			"language": "turkish"
+		},
+		"tr_stem_filter": {
+			"type": "stemmer",
+			"language": "turkish"
 		}
 	},
 	"char_filter": {
@@ -455,6 +602,12 @@
 				"ü=>ue",
 				"ph=>f"
 			]
+		},
+		"zero_width_spaces": {
+			"type": "mapping",
+			"mappings": [
+				"\\u200C=> "
+			]
 		}
 	},
 	"analyzer": {
@@ -463,6 +616,7 @@
 			"filter": [
 				"icu_normalizer",
 				"ar_stop_filter",
+				"arabic_normalization",
 				"icu_folding"
 			],
 			"tokenizer": "icu_tokenizer"
@@ -476,9 +630,32 @@
 			],
 			"tokenizer": "icu_tokenizer"
 		},
+		"bn_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"indic_normalization",
+				"bengali_normalization",
+				"bn_stop_filter",
+				"bn_stem_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"br_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"br_stop_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
 		"ca_analyzer": {
 			"type": "custom",
 			"filter": [
+				"ca_elision_filter",
+				"lowercase",
 				"icu_normalizer",
 				"ca_stop_filter",
 				"icu_folding"
@@ -489,8 +666,8 @@
 			"type": "custom",
 			"filter": [
 				"icu_normalizer",
+				"sorani_normalization",
 				"ckb_stop_filter",
-				"ckb_stem_filter",
 				"icu_folding"
 			],
 			"tokenizer": "icu_tokenizer"
@@ -518,6 +695,7 @@
 			"filter": [
 				"icu_normalizer",
 				"de_stop_filter",
+				"german_normalization",
 				"de_stem_filter",
 				"icu_folding"
 			],
@@ -530,6 +708,7 @@
 			"type": "custom",
 			"filter": [
 				"icu_normalizer",
+				"greek_lowercase_filter",
 				"el_stop_filter",
 				"icu_folding"
 			],
@@ -569,8 +748,13 @@
 			"type": "custom",
 			"filter": [
 				"icu_normalizer",
+				"arabic_normalization",
+				"persian_normalization",
 				"fa_stop_filter",
 				"icu_folding"
+			],
+			"char_filter": [
+				"zero_width_spaces"
 			],
 			"tokenizer": "icu_tokenizer"
 		},
@@ -588,9 +772,19 @@
 			"type": "custom",
 			"filter": [
 				"icu_normalizer",
-				"elision",
+				"fr_elision_filter",
 				"fr_stop_filter",
 				"fr_stem_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"ga_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"ga_elision_filter",
+				"ga_stop_filter",
 				"icu_folding"
 			],
 			"tokenizer": "icu_tokenizer"
@@ -608,6 +802,8 @@
 			"type": "custom",
 			"filter": [
 				"icu_normalizer",
+				"indic_normalization",
+				"hindi_normalization",
 				"hi_stop_filter",
 				"icu_folding"
 			],
@@ -645,6 +841,7 @@
 			"type": "custom",
 			"filter": [
 				"icu_normalizer",
+				"it_elision_filter",
 				"it_stop_filter",
 				"it_stem_filter",
 				"icu_folding"
@@ -672,15 +869,28 @@
 			"filter": [
 				"icu_normalizer",
 				"nl_stop_filter",
+				"nl_stem_override_filter",
+				"nl_stem_filter",
 				"icu_folding"
 			],
 			"tokenizer": "icu_tokenizer"
 		},
-		"no_analyzer": {
+		"nb_analyzer": {
 			"type": "custom",
 			"filter": [
 				"icu_normalizer",
 				"no_stop_filter",
+				"nb_stem_filter",
+				"icu_folding"
+			],
+			"tokenizer": "icu_tokenizer"
+		},
+		"nn_analyzer": {
+			"type": "custom",
+			"filter": [
+				"icu_normalizer",
+				"no_stop_filter",
+				"nn_stem_filter",
 				"icu_folding"
 			],
 			"tokenizer": "icu_tokenizer"
@@ -727,10 +937,15 @@
 			],
 			"tokenizer": "icu_tokenizer"
 		},
+		"th_analyzer": {
+			"type": "thai"
+		},
 		"tr_analyzer": {
 			"type": "custom",
 			"filter": [
 				"icu_normalizer",
+				"apostrophe",
+				"tr_lowercase_filter",
 				"tr_stop_filter",
 				"icu_folding"
 			],

--- a/inc/analyzers.json
+++ b/inc/analyzers.json
@@ -858,7 +858,7 @@
 				"greek_lowercase_filter",
 				"cjk_width"
 			],
-			"tokenizer": "kuromoji_tokenizer"
+			"tokenizer": "kuromoji"
 		},
 		"ko_analyzer": {
 			"type": "cjk",

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -774,18 +774,20 @@ function elasticpress_mapping( array $mapping ) : array {
 				continue;
 			}
 
-			if ( $type === 'synonyms' ) {
-				$synonyms[ "{$sub_type}_{$type}_filter" ] = [
-					'type' => 'synonym_graph',
-					'synonyms_path' => $package_id,
-				];
-			}
-			if ( $type === 'stopwords' ) {
-				$stopwords[ "{$sub_type}_{$type}_filter" ] = [
-					'type' => 'stop',
-					'ignore_case' => true,
-					'stopwords_path' => $package_id,
-				];
+			switch ( $type ) {
+				case 'synonyms':
+					$synonyms[ "{$sub_type}_{$type}_filter" ] = [
+						'type' => 'synonym_graph',
+						'synonyms_path' => $package_id,
+					];
+					break;
+				case 'stopwords':
+					$stopwords[ "{$sub_type}_{$type}_filter" ] = [
+						'type' => 'stop',
+						'ignore_case' => true,
+						'stopwords_path' => $package_id,
+					];
+					break;
 			}
 		}
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -578,7 +578,9 @@ function elasticpress_mapping( array $mapping ) : array {
 		unset( $mapping['settings']['mappings']['post']['properties']['post_title']['fields']['post_title']['analyzer'] );
 	}
 
-	// Handle user dictionary for Japanese tokenizer.
+	/**
+	 * Handle user dictionary for Japanese sites.
+	 */
 	if ( $language === 'ja' ) {
 		$is_network_japanese = get_site_option( 'WPLANG', 'en_US' ) === 'ja';
 		$user_dictionary_file = Packages\get_package_file_path( 'uploaded-user-dictionary' );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -130,7 +130,7 @@ function load_elasticpress() {
 	add_filter( 'register_post_type_args', __NAMESPACE__ . '\\custom_search_results_post_type_args', 10, 2 );
 
 	// Set up packages feature.
-	Packages\setup();
+	Packages\bootstrap();
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -862,11 +862,11 @@ function custom_search_results_post_type_args( array $args, string $post_type ) 
 		return $args;
 	}
 
-	// Use the built in search icon.
-	$args['menu_icon'] = 'dashicons-search';
+	// Hide in admin menu, we'll add it as a subitem of main search config page.
+	$args['show_in_menu'] = 'search-config';
 
 	// Change the menu name to something shorter.
-	$args['labels']['menu_name'] = _x( 'Search Config', 'post type menu name', 'altis' );
+	$args['labels']['all_items'] = _x( 'Custom Search Results', 'post type menu name', 'altis' );
 
 	return $args;
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -101,6 +101,9 @@ function load_elasticpress() {
 	// Filter Options for Facet component settings.
 	add_filter( 'site_option_ep_feature_settings', __NAMESPACE__ . '\\filter_facet_settings' );
 	add_filter( 'option_ep_feature_settings', __NAMESPACE__ . '\\filter_facet_settings' );
+
+	// Set up packages feature.
+	Packages\setup();
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -587,7 +587,7 @@ function elasticpress_mapping( array $mapping ) : array {
 		$is_network_japanese = get_site_option( 'WPLANG', 'en_US' ) === 'ja';
 		$user_dictionary_package_id = Packages\get_package_id( 'uploaded-user-dictionary' );
 		if ( ! $user_dictionary_package_id && $is_network_japanese ) {
-			$user_dictionary_package_id = Packages\get_package_id( 'global-uploaded-user-dictionary' );
+			$user_dictionary_package_id = Packages\get_package_id( 'uploaded-user-dictionary', true );
 		}
 
 		// Check for a package ID and add it to the kuromoji tokenizer.
@@ -612,7 +612,7 @@ function elasticpress_mapping( array $mapping ) : array {
 			$package_id = Packages\get_package_id( "{$sub_type}-{$type}" );
 			// Check for network default.
 			if ( ! $package_id && $is_network_language ) {
-				$package_id = Packages\get_package_id( "global-{$sub_type}-{$type}" );
+				$package_id = Packages\get_package_id( "{$sub_type}-{$type}", true );
 			}
 
 			// Check for a package ID.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -395,10 +395,11 @@ function elasticpress_analyzer_language() : string {
 		'ar'             => 'ar', // arabic.
 		'hy'             => 'hy', // armenian.
 		'eu'             => 'eu', // basque.
-		'pt_br'          => 'pt', // brazilian portuguese.
+		'pt_br'          => 'br', // brazilian portuguese.
 		'bg_bg'          => 'bg', // bulgarian.
+		'bn_bd'          => 'bn', // bengali.
 		'ca'             => 'ca', // catalan.
-		'cs_cz'          => 'cs', // czeh.
+		'cs_cz'          => 'cs', // czech.
 		'da_dk'          => 'da', // danish.
 		'nl_be'          => 'nl', // dutch.
 		'nl_nl'          => 'nl',
@@ -413,6 +414,7 @@ function elasticpress_analyzer_language() : string {
 		'fr_be'          => 'fr', // french.
 		'fr_ca'          => 'fr',
 		'fr_fr'          => 'fr',
+		'ga'             => 'ga', // irish.
 		'gl_es'          => 'gl', // galician.
 		'de_at'          => 'de', // german.
 		'de_ch'          => 'de',
@@ -426,8 +428,8 @@ function elasticpress_analyzer_language() : string {
 		'it_it'          => 'it', // italian.
 		'lv'             => 'lv', // latvian.
 		'lt_lt'          => 'lt', // lithuanian.
-		'nb_no'          => 'no', // norwegian.
-		'nn_no'          => 'no',
+		'nb_no'          => 'nb', // norwegian bokmål.
+		'nn_no'          => 'nn', // norwegian nynorsk.
 		'fa_ir'          => 'fa', // persian.
 		'pl_pl'          => 'pl', // polish.
 		'pt_pt'          => 'pt', // portuguese.
@@ -516,7 +518,7 @@ function elasticpress_mapping( array $mapping ) : array {
 	$mapping['settings']['analysis']['analyzer']['shingle_analyzer'] = [
 		'type' => 'custom',
 		'tokenizer' => 'icu_tokenizer',
-		'filter' => [ 'icu_normalizer', 'icu_folding', 'lowercase', 'shingle_filter' ],
+		'filter' => [ 'icu_normalizer', 'icu_folding', 'shingle_filter' ],
 	];
 
 	// Get analyzer language.
@@ -529,10 +531,6 @@ function elasticpress_mapping( array $mapping ) : array {
 			$mapping['settings']['analysis']['analyzer']['default']['char_filter'] ?? [],
 			[ 'html_strip' ]
 		);
-		// If the last filter was icu_folding then add lowercase filter.
-		if ( end( $mapping['settings']['analysis']['analyzer']['default']['filter'] ) === 'icu_folding' ) {
-			$mapping['settings']['analysis']['analyzer']['default']['filter'][] = 'lowercase';
-		}
 	}
 
 	// Remove deprecated _all parameter.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -514,7 +514,9 @@ function elasticpress_analyzer_language() : string {
  */
 function elasticpress_mapping( array $mapping ) : array {
 
-	// Merge JSON filters, tokenizers and analyzers.
+	/**
+	 * Merge filters, tokenizers and analyzers from JSON config.
+	 */
 	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 	$settings_json = file_get_contents( __DIR__ . '/analyzers.json' );
 	$settings = json_decode( $settings_json, true );
@@ -595,7 +597,12 @@ function elasticpress_mapping( array $mapping ) : array {
 		}
 	}
 
-	// Add a default search analyzer if any custom stopwords or synonyms are provided.
+	/**
+	 * Add a default search analyzer if any custom stopwords or synonyms are provided.
+	 *
+	 * Synonyms and stopwords are quick enough to be applied at search time and avoid
+	 * increasing the index size unnecessarily.
+	 */
 	$types = [ 'synonyms', 'stopwords' ];
 	$is_network_language = get_site_option( 'WPLANG', 'en_US' ) === get_option( 'WPLANG', 'en_US' );
 	$synonyms = [];
@@ -637,16 +644,12 @@ function elasticpress_mapping( array $mapping ) : array {
 			$synonyms,
 			$stopwords
 		);
-		// Add stopwords to default analyzer.
-		$mapping['settings']['analysis']['analyzer']['default']['filter'] = array_merge(
-			array_keys( $stopwords ),
-			$mapping['settings']['analysis']['analyzer']['default']['filter']
-		);
 		// Copy default analyzer to default search.
 		$mapping['settings']['analysis']['analyzer']['default_search'] = $mapping['settings']['analysis']['analyzer']['default'];
 		// Add our custom filters.
 		$mapping['settings']['analysis']['analyzer']['default_search']['filter'] = array_merge(
 			array_keys( $synonyms ),
+			array_keys( $stopwords ),
 			$mapping['settings']['analysis']['analyzer']['default_search']['filter']
 		);
 	}

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -299,8 +299,11 @@ function handle_form() : void {
 				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
 				$result = file_put_contents( $file, $text );
 				if ( ! $result ) {
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					$errors[] = new WP_Error( 'write_package_error', sprintf( __( 'Could not write search package file to %s', 'altis' ), $file ) );
+					$errors[] = new WP_Error(
+						'write_package_error',
+						// translators: %s replaced by file package path.
+						sprintf( __( 'Could not write search package file to %s', 'altis' ), $file )
+					);
 				} else {
 					$package_id = create_package( "manual-{$type}", $file, $for_network );
 					if ( is_wp_error( $package_id ) ) {
@@ -315,8 +318,11 @@ function handle_form() : void {
 			$file = get_package_path( "uploaded-{$type}", $for_network );
 			$result = move_uploaded_file( $_FILES[ $file_field ]['tmp_name'], $file );
 			if ( ! $result ) {
-				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				$errors[] = new WP_Error( 'write_package_error', sprintf( __( 'Could not write search package file to %s', 'altis' ), $file ) );
+				$errors[] = new WP_Error(
+					'write_package_error',
+					// translators: %s replaced by search package file path.
+					sprintf( __( 'Could not write search package file to %s', 'altis' ), $file )
+				);
 			} else {
 				$package_id = create_package( "uploaded-{$type}", $file, $for_network );
 				if ( is_wp_error( $package_id ) ) {
@@ -345,7 +351,9 @@ function handle_form() : void {
 	}
 
 	// Store the errors.
-	array_map( __NAMESPACE__ . '\\add_error_message', $errors );
+	foreach ( $errors as $error ) {
+		add_error_message( $error );
+	}
 
 	// Schedule mapping and index updates.
 	if ( empty( $errors ) ) {

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -404,7 +404,7 @@ function do_settings_update( array $settings, bool $update_data = false ) {
 
 	// Update all data async if required.
 	if ( $update_data ) {
-		ep_remote_request( ep_get_index_name() . '/_update_by_query?conflicts=proceed', [
+		ep_remote_request( ep_get_index_name() . '/_update_by_query?conflicts=proceed&wait_for_completion=false', [
 			'method' => 'POST',
 		] );
 	}

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -447,14 +447,8 @@ function delete_package( string $slug, bool $for_network = false ) {
 
 	$file = get_package_path( $slug, $for_network );
 
-	// Ensure file exists.
-	if ( ! file_exists( $file ) ) {
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		trigger_error( sprintf( 'The package file %s does not exist.', $file ), E_USER_WARNING );
-	} else {
-		// Delete the file.
-		unlink( $file );
-	}
+	// Delete the file.
+	unlink( $file );
 
 	// Remove the stored package ID.
 	if ( $for_network ) {

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -16,8 +16,10 @@ use Aws\ElasticsearchService\ElasticsearchServiceClient;
  * @return void
  */
 function setup() {
-	add_action( 'network_admin_menu', __NAMESPACE__ . '\\admin_menu' );
+	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
+	add_action( 'admin_init', __NAMESPACE__ . '\\handle_form' );
 	add_action( 'admin_menu', __NAMESPACE__ . '\\admin_menu' );
+	add_action( 'network_admin_menu', __NAMESPACE__ . '\\admin_menu' );
 }
 
 /**
@@ -25,7 +27,7 @@ function setup() {
  *
  * @return ElasticsearchServiceClient
  */
-function get_aws_client() : ElasticsearchServiceClient {
+function get_aes_client() : ElasticsearchServiceClient {
 	return Altis\get_aws_sdk()->createElasticsearchService( [
 		'version' => '2015-01-01',
 	] );
@@ -37,16 +39,297 @@ function get_aws_client() : ElasticsearchServiceClient {
  * @return void
  */
 function admin_menu() {
-	add_menu_page(
+	add_submenu_page(
+		is_network_admin() ? 'settings.php' : 'options-general.php',
 		__( 'Search Configuration', 'altis' ),
-		__( 'Search', 'altis' ),
-		'manage_options',
+		__( 'Search Config', 'altis' ),
+		is_network_admin() ? 'manage_network_options' : 'manage_options',
 		'search-config',
-		__NAMESPACE__ . '\\admin_page',
-		'dashicons-search'
+		__NAMESPACE__ . '\\admin_page'
 	);
 }
 
+/**
+ * Enqueue scripts and styles for the search config form.
+ *
+ * @param string $hook_suffix The admin page hook.
+ * @return void
+ */
+function enqueue_scripts( string $hook_suffix ) {
+	if ( $hook_suffix !== 'settings_page_search-config' ) {
+		return;
+	}
+
+	wp_enqueue_style( 'wp-components' );
+}
+
+/**
+ * Includes the search config page template.
+ *
+ * @return void
+ */
 function admin_page() {
-	echo '<h1>search config</h1>';
+	$types = [ 'synonyms', 'stopwords', 'user_dictionary' ];
+
+	$prefix = is_network_admin() ? 'global-' : '';
+
+	foreach ( $types as $type ) {
+		$uploaded_file_var = "{$type}_uploaded_file";
+		$manual_file_var = "{$type}_uploaded_file";
+		$text_var = "{$type}_text";
+		$file_date_var = "{$type}_file_date";
+
+		$$uploaded_file_var = get_package_file_path( "{$prefix}uploaded-{$type}" );
+		$$manual_file_var = get_package_file_path( "{$prefix}manual-{$type}" );
+
+		$$text_var = '';
+		if ( file_exists( $$manual_file_var ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$$text_var = file_get_contents( $$manual_file_var );
+		}
+
+		$$file_date_var = false;
+		if ( file_exists( $$uploaded_file_var ) ) {
+			$$file_date_var = filemtime( $$uploaded_file_var );
+		}
+	}
+
+	include __DIR__ . '/templates/config.php';
+}
+
+/**
+ * Returns the base directory for storing Elasticsearch packages.
+ *
+ * @return string
+ */
+function get_packages_path() : string {
+	return wp_upload_dir()['basedir'] . '/search';
+}
+
+/**
+ * Get a package file path. Returns the path if the file exists
+ * or null on failure.
+ *
+ * @param string $type A file prefix for the package file.
+ * @param int|null $blog_id The site ID to get the file path for.
+ * @param int|null $network_id The network ID to get the file path for.
+ * @return string
+ */
+function get_package_file_path( string $type, ?int $blog_id = null, ?int $network_id = null ) : string {
+	return sprintf(
+		'%s/%s-%d-%d.txt',
+		get_packages_path(),
+		$type,
+		$network_id ?? get_current_network_id(),
+		$blog_id ?? get_current_blog_id()
+	);
+}
+
+/**
+ * Process the packages form.
+ *
+ * @return void
+ */
+function handle_form() {
+	if ( ! isset( $_POST['action'] ) || $_POST['action'] !== 'altis-search-config' ) {
+		return;
+	}
+
+	if ( ! check_admin_referer( 'altis-search-config', '_altisnonce' ) ) {
+		return;
+	}
+
+	// Set a global prefix in network admin.
+	$prefix = is_network_admin() ? 'global-' : '';
+
+	// Collect packages to create and associate.
+	$packages = [];
+
+	// The different types of package.
+	$types = [ 'synonyms', 'stopwords', 'user-dictionary' ];
+
+	foreach ( $types as $type ) {
+		$text_field = "{$type}-text";
+		$file_field = "{$type}-file";
+		$remove_field = "{$type}-remove";
+
+		// Handle manual entry.
+		if ( isset( $_POST[ $text_field ] ) && ! empty( $_POST[ $text_field ] ) ) {
+			$synonyms_text = sanitize_textarea_field( $_POST[ $text_field ] );
+			$synonyms_file = get_package_file_path( "{$prefix}manual-{$type}" );
+			$has_changed = false;
+
+			// Check for updates.
+			if ( file_exists( $synonyms_file ) ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				$has_changed = $synonyms_text !== file_get_contents( $synonyms_file );
+			}
+
+			// Write to uploads.
+			if ( $has_changed ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
+				file_put_contents( $synonyms_file, $synonyms_text );
+				$packages[] = $synonyms_file;
+			}
+		}
+
+		// Handle file upload.
+		if ( ! empty( $_FILES ) && isset( $_FILES[ $file_field ] ) ) {
+			$synonyms_file = get_package_file_path( "${$prefix}uploaded-{$type}" );
+			move_uploaded_file( $_FILES[ $file_field ]['tmp_name'], $synonyms_file );
+			$packages[] = $synonyms_file;
+		}
+
+		// Delete file if remove submit clicked.
+		if ( isset( $_POST[ $remove_field ] ) ) {
+			delete_package( get_package_file_path( "${$prefix}uploaded-{$type}" ) );
+		}
+	}
+
+	foreach ( $packages as $package ) {
+		// Create a new package and associate it.
+		$package_id = create_package( $package );
+		if ( $package_id ) {
+			// Store package ID for file.
+			$name = basename( $package );
+			update_site_option( "altis_search_package_{$name}", $package_id );
+		}
+	}
+}
+
+/**
+ * Get the package ID for a given file path.
+ *
+ * @param string $file The file to get the package ID for.
+ * @return string|null
+ */
+function get_package_id( string $file ) : ?string {
+	$name = basename( $file );
+
+	$package_id = get_site_option( "altis_search_package_{$name}" );
+	if ( $package_id ) {
+		return $package_id;
+	}
+
+	return null;
+}
+
+/**
+ * Create and associate a package file with AES, removing any existing
+ * files with a matching name.
+ *
+ * @param string $file The full S3 package file path.
+ * @return string|null The package ID for referencing in analysers.
+ */
+function create_package( string $file ) : ?string {
+
+	// Ensure file exists.
+	if ( ! file_exists( $file ) ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		trigger_error( sprintf( 'The given package filepath %s does not exist.', $file ), E_USER_WARNING );
+		return null;
+	}
+
+	/**
+	 * Override the package ID for a given package file name.
+	 *
+	 * @param string|null The package ID for the given file.
+	 * @param string $file The full package file path.
+	 */
+	$package_id = apply_filters( 'altis.search.package_id', null, $file );
+	if ( $package_id !== null ) {
+		return $package_id;
+	}
+
+	// Check file is an S3 file path.
+	if ( strpos( $file, 's3://' ) !== 0 ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		trigger_error( sprintf( 'The given package filepath %s is not a valid S3 file path.', $file ), E_USER_WARNING );
+		return null;
+	}
+
+	// Get AES client.
+	$client = get_aes_client();
+
+	// Use the filename for the package name and for matching.
+	$name = basename( $file );
+
+	// Derive S3 bucket and path.
+	preg_match( '#^s3://([^/]+)/(.*?)$#', $file, $s3_file_parts );
+	$s3_bucket = defined( 'S3_UPLOADS_BUCKET' ) ? S3_UPLOADS_BUCKET : $s3_file_parts[1];
+	$s3_key = $s3_file_parts[2];
+
+	// Get domain.
+	$domains = $client->listDomainNames();
+	$domain = $domains['DomainNames'][0]['DomainName'] ?? false;
+
+	if ( empty( $domain ) ) {
+		trigger_error( 'Could not find an AWS ElasticSearch Service Domain to associate the package with.', E_USER_WARNING );
+		return null;
+	}
+
+	// Get old package if one exists with same name.
+	$existing = $client->describePackages( [
+		'Filter' => [
+			'Name' => 'PackageName',
+			'Value' => $name,
+		],
+	] );
+
+	// Create a new package.
+	$new_package = $client->createPackage( [
+		'PackageName' => $name, // required.
+		'PackageSource' => [ // required.
+			'S3BucketName' => $s3_bucket,
+			'S3Key' => $s3_key,
+		],
+		'PackageType' => 'TXT-DICTIONARY',
+	] );
+
+	// Associate the package with the ES domain.
+	$client->associatePackage( [
+		'DomainName' => $domain, // required.
+		'PackageID' => $new_package['PackageDetails']['PackageID'], // required.
+	] );
+
+	// Dissociate and remove the old version of the package.
+	if ( ! empty( $existing['PackageDetailsList'] ) ) {
+		$existing_package_id = $existing['PackageDetailsList'][0]['PackageID'];
+		$client->dissociatePackage( [
+			'DomainName' => $domain, // required.
+			'PackageID' => $existing_package_id, // required.
+		] );
+		$client->deletePackage( [
+			'PackageID' => $existing_package_id,
+		] );
+	}
+
+	// Return the reference used to get the package in an analyzer.
+	return 'analyzers/' . $new_package['PackageDetails']['PackageID'];
+}
+
+/**
+ * Removes the stored package ID and file for a given package.
+ *
+ * @param string $file The package file path.
+ * @return bool
+ */
+function delete_package( string $file ) : bool {
+
+	// Ensure file exists.
+	if ( ! file_exists( $file ) ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		trigger_error( sprintf( 'The given package filepath %s does not exist.', $file ), E_USER_WARNING );
+		return false;
+	}
+
+	// Delete the file.
+	unlink( $file );
+
+	$name = basename( $file );
+
+	// Remove the stored package ID.
+	delete_site_option( "altis_search_package_{$name}" );
+
+	return true;
 }

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -106,7 +106,7 @@ function admin_page() {
  * @return string
  */
 function get_packages_path() : string {
-	return wp_upload_dir()['basedir'] . '/search';
+	return preg_replace( '#/sites/\d+#', '', wp_upload_dir()['basedir'] . '/search' );
 }
 
 /**

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -296,11 +296,11 @@ function create_package( string $slug, string $file, bool $for_network = false )
 	 *
 	 * Default usage is to trigger an update to the ES mapping.
 	 *
+	 * @param string $package_id The package ID.
 	 * @param string $slug The package slug.
-	 * @param string $package_id The package ID / path.
 	 * @param bool $for_network True if the package was created at the network level.
 	 */
-	do_action( 'altis.search.created_package', $slug, $package_id, $for_network );
+	do_action( 'altis.search.created_package', $package_id, $slug, $for_network );
 
 	// Return the reference used to get the package in an analyzer.
 	return $package_id;

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -345,7 +345,11 @@ function handle_form() : void {
 
 	// Redirect back to form.
 	$redirect_url = is_network_admin() ? network_admin_url( 'settings.php' ) : admin_url( 'admin.php' );
-	wp_safe_redirect( $redirect_url . '?page=search-config&did_update=1' );
+	$redirect_url = add_query_arg( [
+		'page' => 'search-config',
+		'did_update' => 1,
+	], $redirect_url );
+	wp_safe_redirect( $redirect_url );
 	exit;
 }
 

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -30,6 +30,7 @@ function setup() {
 function get_aes_client() : ElasticsearchServiceClient {
 	return Altis\get_aws_sdk()->createElasticsearchService( [
 		'version' => '2015-01-01',
+		'region' => Altis\get_environment_region(),
 	] );
 }
 
@@ -75,7 +76,7 @@ function admin_page() {
 
 	foreach ( $types as $type ) {
 		$uploaded_file_var = "{$type}_uploaded_file";
-		$manual_file_var = "{$type}_uploaded_file";
+		$manual_file_var = "{$type}_manual_file";
 		$text_var = "{$type}_text";
 		$file_date_var = "{$type}_file_date";
 
@@ -155,29 +156,29 @@ function handle_form() {
 
 		// Handle manual entry.
 		if ( isset( $_POST[ $text_field ] ) && ! empty( $_POST[ $text_field ] ) ) {
-			$synonyms_text = sanitize_textarea_field( $_POST[ $text_field ] );
-			$synonyms_file = get_package_file_path( "{$prefix}manual-{$type}" );
-			$has_changed = false;
+			$text = sanitize_textarea_field( $_POST[ $text_field ] );
+			$file = get_package_file_path( "{$prefix}manual-{$type}" );
+			$has_changed = true;
 
 			// Check for updates.
-			if ( file_exists( $synonyms_file ) ) {
+			if ( file_exists( $file ) ) {
 				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-				$has_changed = $synonyms_text !== file_get_contents( $synonyms_file );
+				$has_changed = $text !== file_get_contents( $file );
 			}
 
 			// Write to uploads.
 			if ( $has_changed ) {
 				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
-				file_put_contents( $synonyms_file, $synonyms_text );
-				$packages[] = $synonyms_file;
+				file_put_contents( $file, $text );
+				$packages[] = $file;
 			}
 		}
 
 		// Handle file upload.
-		if ( ! empty( $_FILES ) && isset( $_FILES[ $file_field ] ) ) {
-			$synonyms_file = get_package_file_path( "${$prefix}uploaded-{$type}" );
-			move_uploaded_file( $_FILES[ $file_field ]['tmp_name'], $synonyms_file );
-			$packages[] = $synonyms_file;
+		if ( ! empty( $_FILES ) && isset( $_FILES[ $file_field ] ) && ! empty( $_FILES[ $file_field ]['tmp_name'] ) ) {
+			$file = get_package_file_path( "${$prefix}uploaded-{$type}" );
+			move_uploaded_file( $_FILES[ $file_field ]['tmp_name'], $file );
+			$packages[] = $file;
 		}
 
 		// Delete file if remove submit clicked.

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -80,8 +80,10 @@ function admin_page() {
 		$text_var = "{$type}_text";
 		$file_date_var = "{$type}_file_date";
 
-		$$uploaded_file_var = get_package_file_path( "{$prefix}uploaded-{$type}" );
-		$$manual_file_var = get_package_file_path( "{$prefix}manual-{$type}" );
+		$file_type_string = str_replace( '_', '-', $type );
+
+		$$uploaded_file_var = get_package_file_path( "{$prefix}uploaded-{$file_type_string}" );
+		$$manual_file_var = get_package_file_path( "{$prefix}manual-{$file_type_string}" );
 
 		$$text_var = '';
 		if ( file_exists( $$manual_file_var ) ) {
@@ -176,14 +178,14 @@ function handle_form() {
 
 		// Handle file upload.
 		if ( ! empty( $_FILES ) && isset( $_FILES[ $file_field ] ) && ! empty( $_FILES[ $file_field ]['tmp_name'] ) ) {
-			$file = get_package_file_path( "${$prefix}uploaded-{$type}" );
+			$file = get_package_file_path( "{$prefix}uploaded-{$type}" );
 			move_uploaded_file( $_FILES[ $file_field ]['tmp_name'], $file );
 			$packages[] = $file;
 		}
 
 		// Delete file if remove submit clicked.
 		if ( isset( $_POST[ $remove_field ] ) ) {
-			delete_package( get_package_file_path( "${$prefix}uploaded-{$type}" ) );
+			delete_package( get_package_file_path( "{$prefix}uploaded-{$type}" ) );
 		}
 	}
 

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -21,7 +21,7 @@ use WP_Error;
 function setup() {
 	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
 	add_action( 'admin_init', __NAMESPACE__ . '\\handle_form' );
-	add_action( 'admin_menu', __NAMESPACE__ . '\\admin_menu' );
+	add_action( 'admin_menu', __NAMESPACE__ . '\\admin_menu', 5 );
 	add_action( 'network_admin_menu', __NAMESPACE__ . '\\admin_menu' );
 	add_filter( 'removable_query_args', __NAMESPACE__ . '\\add_removable_query_args' );
 
@@ -36,13 +36,14 @@ function setup() {
  * @return void
  */
 function admin_menu() {
-	add_submenu_page(
-		is_network_admin() ? 'settings.php' : 'options-general.php',
+	add_menu_page(
 		__( 'Search Configuration', 'altis' ),
 		__( 'Search Config', 'altis' ),
 		is_network_admin() ? 'manage_network_options' : 'manage_options',
 		'search-config',
-		__NAMESPACE__ . '\\admin_page'
+		__NAMESPACE__ . '\\admin_page',
+		'dashicons-search',
+		171
 	);
 }
 
@@ -64,7 +65,7 @@ function add_removable_query_args( array $removable_query_args ) : array {
  * @return void
  */
 function enqueue_scripts( string $hook_suffix ) {
-	if ( $hook_suffix !== 'settings_page_search-config' ) {
+	if ( $hook_suffix !== 'toplevel_page_search-config' ) {
 		return;
 	}
 

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -388,6 +388,9 @@ function create_package( string $slug, string $file, bool $for_network = false )
 	 * @param bool $for_network True if the package is a network level package.
 	 */
 	$package_id = apply_filters( 'altis.search.create_package_id', $package_id, $slug, $file, $for_network );
+	if ( is_wp_error( $package_id ) ) {
+		return $package_id;
+	}
 
 	// Store package ID.
 	if ( $for_network ) {

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -148,8 +148,9 @@ function admin_page() {
  * Sets the search config error message.
  *
  * @param WP_Error $error The error object to add.
+ * @param bool $for_network Whether this should be added as a network level error.
  */
-function add_error_message( WP_Error $error ) {
+function add_error_message( WP_Error $error, bool $for_network = false ) {
 	static $errors = [];
 	$errors[] = $error;
 	$errors = array_map( function ( $error ) {
@@ -162,7 +163,7 @@ function add_error_message( WP_Error $error ) {
 		];
 	}, $errors );
 
-	if ( is_network_admin() ) {
+	if ( is_network_admin() || $for_network ) {
 		update_site_option( 'altis_search_config_error', $errors );
 	} else {
 		update_option( 'altis_search_config_error', $errors );

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -7,8 +7,7 @@
 
 namespace Altis\Enhanced_Search\Packages;
 
-use Altis;
-use Aws\ElasticsearchService\ElasticsearchServiceClient;
+use Altis\Enhanced_Search;
 
 /**
  * Bind hooks for ElasticSearch Packages.
@@ -20,18 +19,9 @@ function setup() {
 	add_action( 'admin_init', __NAMESPACE__ . '\\handle_form' );
 	add_action( 'admin_menu', __NAMESPACE__ . '\\admin_menu' );
 	add_action( 'network_admin_menu', __NAMESPACE__ . '\\admin_menu' );
-}
 
-/**
- * Get Elasticsearch Service Client.
- *
- * @return ElasticsearchServiceClient
- */
-function get_aes_client() : ElasticsearchServiceClient {
-	return Altis\get_aws_sdk()->createElasticsearchService( [
-		'version' => '2015-01-01',
-		'region' => Altis\get_environment_region(),
-	] );
+	// Background tasks.
+	add_action( 'altis.search.update_index_settings', __NAMESPACE__ . '\\update_index_settings', 10, 2 );
 }
 
 /**
@@ -72,7 +62,7 @@ function enqueue_scripts( string $hook_suffix ) {
 function admin_page() {
 	$types = [ 'synonyms', 'stopwords', 'user_dictionary' ];
 
-	$prefix = is_network_admin() ? '' : 'sites/' . get_current_blog_id() . '/';
+	$for_network = is_network_admin();
 
 	foreach ( $types as $type ) {
 		$uploaded_file_var = "{$type}_uploaded_file";
@@ -82,8 +72,8 @@ function admin_page() {
 
 		$file_type_string = str_replace( '_', '-', $type );
 
-		$$uploaded_file_var = get_package_path( "{$prefix}uploaded-{$file_type_string}" );
-		$$manual_file_var = get_package_path( "{$prefix}manual-{$file_type_string}" );
+		$$uploaded_file_var = get_package_path( "uploaded-{$file_type_string}", $for_network );
+		$$manual_file_var = get_package_path( "manual-{$file_type_string}", $for_network );
 
 		$$text_var = '';
 		if ( file_exists( $$manual_file_var ) ) {
@@ -97,7 +87,19 @@ function admin_page() {
 		}
 	}
 
+	if ( $for_network ) {
+		$error = get_site_option( 'altis_search_config_error', false );
+	} else {
+		$error = get_option( 'altis_search_config_error', false );
+	}
+
 	include __DIR__ . '/templates/config.php';
+
+	if ( $for_network ) {
+		delete_site_option( 'altis_search_config_error' );
+	} else {
+		delete_option( 'altis_search_config_error' );
+	}
 }
 
 /**
@@ -105,15 +107,15 @@ function admin_page() {
  *
  * @return string
  */
-function get_packages_path() : string {
-	$path = WP_CONTENT_DIR . '/es-packages';
+function get_packages_dir() : string {
+	$path = '/usr/share/elasticsearch/config/es-packages';
 
 	/**
 	 * Filter the path at which Elasticsearch package files are stored.
 	 *
 	 * @param string $path Absolute directory path, defaults to wp-content/es-packages.
 	 */
-	$path = apply_filters( 'altis.search.packages_path', $path );
+	$path = apply_filters( 'altis.search.packages_dir', $path );
 
 	return $path;
 }
@@ -123,12 +125,14 @@ function get_packages_path() : string {
  * or null on failure.
  *
  * @param string $slug A slug ID for the package file.
+ * @param bool $for_network If true returns path for network level package.
  * @return string
  */
-function get_package_path( string $slug ) : string {
+function get_package_path( string $slug, bool $for_network = false ) : string {
 	$path = sprintf(
-		'%s/%s.txt',
-		get_packages_path(),
+		'%s/%s-%s.txt',
+		get_packages_dir(),
+		$for_network ? 'global' : 'site-' . get_current_blog_id(),
 		$slug
 	);
 
@@ -139,15 +143,26 @@ function get_package_path( string $slug ) : string {
  * Get the package ID for a given file path.
  *
  * @param string $slug The package slug to get the package ID for.
+ * @param bool $for_network If true get the network level package ID.
  * @return string|null
  */
-function get_package_id( string $slug ) : ?string {
-	$package_id = get_site_option( "altis_search_package_{$slug}" );
-	if ( ! empty( $package_id ) ) {
-		return $package_id;
+function get_package_id( string $slug, bool $for_network = false ) : ?string {
+	if ( $for_network ) {
+		$package_id = get_site_option( "altis_search_package_{$slug}", null );
+	} else {
+		$package_id = get_option( "altis_search_package_{$slug}", null );
 	}
 
-	return null;
+	/**
+	 * Filter the returned package ID for a given slug.
+	 *
+	 * @param string|null $package_id The package ID to return.
+	 * @param string $slug The package slug.
+	 * @param bool $for_network True for network level package.
+	 */
+	$package_id = apply_filters( 'altis.search.get_package_id', $package_id, $slug, $for_network );
+
+	return $package_id;
 }
 
 /**
@@ -164,8 +179,17 @@ function handle_form() {
 		return;
 	}
 
-	// Set a global prefix in network admin.
-	$prefix = is_network_admin() ? '' : 'sites/' . get_current_blog_id() . '/';
+	// Ensure upload directory exists.
+	$base_dir = get_packages_dir();
+	if ( ! file_exists( $base_dir ) ) {
+		wp_mkdir_p( $base_dir );
+	}
+
+	// Set a flag for whether this is site level or network level.
+	$for_network = is_network_admin();
+
+	// Track whether the index needs to be updated after any package updates.
+	$should_update_indexes = false;
 
 	// The different types of package.
 	$types = [ 'synonyms', 'stopwords', 'user-dictionary' ];
@@ -178,7 +202,7 @@ function handle_form() {
 		// Handle manual entry.
 		if ( isset( $_POST[ $text_field ] ) && ! empty( $_POST[ $text_field ] ) ) {
 			$text = sanitize_textarea_field( $_POST[ $text_field ] );
-			$file = get_package_path( "{$prefix}manual-{$type}" );
+			$file = get_package_path( "manual-{$type}", $for_network );
 			$has_changed = true;
 
 			// Check for updates.
@@ -191,22 +215,36 @@ function handle_form() {
 			if ( $has_changed ) {
 				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
 				file_put_contents( $file, $text );
-				create_package( "{$prefix}manual-{$type}", $file );
+				create_package( "manual-{$type}", $file, $for_network );
 			}
 		}
 
 		// Handle file upload.
 		if ( ! empty( $_FILES ) && isset( $_FILES[ $file_field ] ) && ! empty( $_FILES[ $file_field ]['tmp_name'] ) ) {
-			$file = get_package_path( "{$prefix}uploaded-{$type}" );
+			$file = get_package_path( "uploaded-{$type}", $for_network );
 			move_uploaded_file( $_FILES[ $file_field ]['tmp_name'], $file );
-			create_package( "{$prefix}uploaded-{$type}", $file );
+			create_package( "uploaded-{$type}", $file, $for_network );
+			// User dictionary update means we should update the indexed data.
+			if ( $type === 'user-dictionary' ) {
+				$should_update_indexes = true;
+			}
 		}
 
 		// Delete file if remove submit clicked.
 		if ( isset( $_POST[ $remove_field ] ) ) {
-			delete_package( "{$prefix}uploaded-{$type}" );
+			delete_package( "uploaded-{$type}", $for_network );
+			// User dictionary update means we should update the indexed data.
+			if ( $type === 'user-dictionary' ) {
+				$should_update_indexes = true;
+			}
 		}
 	}
+
+	// Schedule mapping and index updates.
+	wp_schedule_single_event( time(), 'altis.search.update_index_settings', [
+		$for_network,
+		$should_update_indexes,
+	] );
 
 	// Redirect back to form.
 	$redirect_url = is_network_admin() ? network_admin_url( 'settings.php' ) : admin_url( 'options-general.php' );
@@ -220,9 +258,10 @@ function handle_form() {
  *
  * @param string $slug The package slug.
  * @param string $file The package file path.
+ * @param bool $for_network If true creates the package at the network level.
  * @return string|null The package ID for referencing in analysers.
  */
-function create_package( string $slug, string $file ) : ?string {
+function create_package( string $slug, string $file, bool $for_network = false ) : ?string {
 
 	// Ensure file exists.
 	if ( ! file_exists( $file ) ) {
@@ -236,15 +275,32 @@ function create_package( string $slug, string $file ) : ?string {
 	$package_id = $file;
 
 	/**
-	 * Override the package ID for a given package file name.
+	 * Override the package ID on creation for a given package file name.
 	 *
 	 * @param string|null The package ID for the given file.
+	 * @param string $slug The package slug.
 	 * @param string $file The full package file path.
+	 * @param bool $for_network True if the package is a network level package.
 	 */
-	$package_id = apply_filters( 'altis.search.package_id', null, $file );
+	$package_id = apply_filters( 'altis.search.create_package_id', $package_id, $slug, $file, $for_network );
 
-	// Store package ID for file.
-	update_site_option( "altis_search_package_{$slug}", $package_id );
+	// Store package ID.
+	if ( $for_network ) {
+		update_site_option( "altis_search_package_{$slug}", $package_id );
+	} else {
+		update_option( "altis_search_package_{$slug}", $package_id );
+	}
+
+	/**
+	 * Action triggered when a new package has been created.
+	 *
+	 * Default usage is to trigger an update to the ES mapping.
+	 *
+	 * @param string $slug The package slug.
+	 * @param string $package_id The package ID / path.
+	 * @param bool $for_network True if the package was created at the network level.
+	 */
+	do_action( 'altis.search.created_package', $slug, $package_id, $for_network );
 
 	// Return the reference used to get the package in an analyzer.
 	return $package_id;
@@ -254,9 +310,10 @@ function create_package( string $slug, string $file ) : ?string {
  * Removes the stored package ID and file for a given package.
  *
  * @param string $slug The package file path.
+ * @param bool $for_network If true deletes the network level package.
  * @return bool
  */
-function delete_package( string $slug ) : bool {
+function delete_package( string $slug, bool $for_network = false ) : bool {
 	$file = get_package_path( $slug );
 
 	// Ensure file exists.
@@ -268,6 +325,87 @@ function delete_package( string $slug ) : bool {
 		unlink( $file );
 	}
 
+	// Get the package ID to pass to action hook.
+	$package_id = get_package_id( $slug, $for_network );
+
 	// Remove the stored package ID.
-	return delete_site_option( "altis_search_package_{$slug}" );
+	if ( $for_network ) {
+		$deleted = delete_site_option( "altis_search_package_{$slug}" );
+	} else {
+		$deleted = delete_option( "altis_search_package_{$slug}" );
+	}
+
+	/**
+	 * Action triggered when a package is deleted.
+	 *
+	 * @param string $package_id The package ID.
+	 * @param string $slug The package slug.
+	 * @param bool $for_network Whether this is for the network level or site level.
+	 * @param bool $deleted Whether the option was successfully deleted or not.
+	 */
+	do_action( 'altis.search.deleted_package', $package_id, $slug, $for_network, $deleted );
+
+	return $deleted;
+}
+
+/**
+ * Update the index settings after upload. For stopwords and synonyms
+ * no reindexing of data is required as they are applied at search time.
+ *
+ * If the data needs to be updated such as if the Japanese user dictionary
+ * is updated then $update_index allows for updating using `_update_by_query`.
+ *
+ * Note this function should be run as a background task only.
+ *
+ * @param boolean $for_network Whether this is a network wide mapping update.
+ * @param boolean $update_data Whether the index data should be updated as well.
+ * @return void
+ */
+function update_index_settings( bool $for_network = false, bool $update_data = false ) {
+	// Get latest settings.
+	$mapping = Enhanced_Search\elasticpress_mapping( [] );
+	$settings = $mapping['settings'];
+
+	if ( $for_network ) {
+		$sites = ep_get_sites( 0 );
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+			do_settings_update( $settings, $update_data );
+			restore_current_blog();
+		}
+	} else {
+		do_settings_update( $settings, $update_data );
+	}
+}
+
+/**
+ * Makes the Elasticsearch requests to update the index settings.
+ *
+ * @param array $settings The updated settings.
+ * @param boolean $update_data Whether to update data in the index.
+ * @return void
+ */
+function do_settings_update( array $settings, bool $update_data = false ) {
+	// Close the index.
+	ep_remote_request( ep_get_index_name() . '/_close', [
+		'method' => 'POST',
+	], [], 'close_index' );
+
+	// Update the settings.
+	ep_remote_request( ep_get_index_name() . '/_settings', [
+		'method' => 'PUT',
+		'body' => wp_json_encode( $settings ),
+	], [], 'put_settings' );
+
+	// Open the index.
+	ep_remote_request( ep_get_index_name() . '/_open', [
+		'method' => 'POST',
+	], [], 'open_index' );
+
+	// Update all data async if required.
+	if ( $update_data ) {
+		ep_remote_request( ep_get_index_name() . '/_update_by_query?conflicts=proceed', [
+			'method' => 'POST',
+		] );
+	}
 }

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -301,7 +301,7 @@ function handle_form() : void {
 				if ( ! $result ) {
 					$errors[] = new WP_Error(
 						'write_package_error',
-						// translators: %s replaced by file package path.
+						// translators: %s replaced by search file package path.
 						sprintf( __( 'Could not write search package file to %s', 'altis' ), $file )
 					);
 				} else {

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -314,7 +314,7 @@ function create_package( string $slug, string $file, bool $for_network = false )
  * @return bool
  */
 function delete_package( string $slug, bool $for_network = false ) : bool {
-	$file = get_package_path( $slug );
+	$file = get_package_path( $slug, $for_network );
 
 	// Ensure file exists.
 	if ( ! file_exists( $file ) ) {

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Altis Search Packages.
+ *
+ * @package altis/search
+ */
+
+namespace Altis\Enhanced_Search\Packages;
+
+use Altis;
+use Aws\ElasticsearchService\ElasticsearchServiceClient;
+
+/**
+ * Bind hooks for ElasticSearch Packages.
+ *
+ * @return void
+ */
+function setup() {
+	add_action( 'network_admin_menu', __NAMESPACE__ . '\\admin_menu' );
+	add_action( 'admin_menu', __NAMESPACE__ . '\\admin_menu' );
+}
+
+/**
+ * Get Elasticsearch Service Client.
+ *
+ * @return ElasticsearchServiceClient
+ */
+function get_aws_client() : ElasticsearchServiceClient {
+	return Altis\get_aws_sdk()->createElasticsearchService( [
+		'version' => '2015-01-01',
+	] );
+}
+
+/**
+ * Add network admin page.
+ *
+ * @return void
+ */
+function admin_menu() {
+	add_menu_page(
+		__( 'Search Configuration', 'altis' ),
+		__( 'Search', 'altis' ),
+		'manage_options',
+		'search-config',
+		__NAMESPACE__ . '\\admin_page',
+		'dashicons-search'
+	);
+}
+
+function admin_page() {
+	echo '<h1>search config</h1>';
+}

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -144,9 +144,9 @@ function admin_page() : void {
 
 	if ( ! empty( $errors ) ) {
 		if ( $for_network ) {
-			delete_site_option( 'altis_search_config_error' );
+			delete_site_transient( 'altis_search_config_error' );
 		} else {
-			delete_option( 'altis_search_config_error' );
+			delete_transient( 'altis_search_config_error' );
 		}
 	}
 }
@@ -172,9 +172,9 @@ function add_error_message( WP_Error $error, bool $for_network = false ) : void 
 	}, $errors );
 
 	if ( is_network_admin() || $for_network ) {
-		update_site_option( 'altis_search_config_error', $errors );
+		set_site_transient( 'altis_search_config_error', $errors );
 	} else {
-		update_option( 'altis_search_config_error', $errors );
+		set_transient( 'altis_search_config_error', $errors );
 	}
 }
 

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -69,7 +69,12 @@ function enqueue_scripts( string $hook_suffix ) : void {
 		return;
 	}
 
-	wp_enqueue_style( 'wp-components' );
+	wp_enqueue_style(
+		'altis-search-packages',
+		plugin_dir_url( dirname( __FILE__, 2 ) ) . 'assets/packages.css',
+		[ 'wp-components' ],
+		'2020-08-26-01'
+	);
 }
 
 /**

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -18,7 +18,7 @@ use WP_Error;
  *
  * @return void
  */
-function setup() {
+function bootstrap() {
 	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
 	add_action( 'admin_init', __NAMESPACE__ . '\\handle_form' );
 	add_action( 'admin_menu', __NAMESPACE__ . '\\admin_menu', 5 );

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -83,55 +83,52 @@ function enqueue_scripts( string $hook_suffix ) : void {
  * @return void
  */
 function admin_page() : void {
-	$types = [ 'synonyms', 'stopwords', 'user_dictionary' ];
+	$types = [
+		'synonyms' => [],
+		'stopwords' => [],
+		'user_dictionary' => [],
+	];
 
 	$for_network = is_network_admin();
 
-	foreach ( $types as $type ) {
-		$uploaded_file_var = "{$type}_uploaded_file";
-		$manual_file_var = "{$type}_manual_file";
-		$text_var = "{$type}_text";
-		$file_date_var = "{$type}_file_date";
-		$uploaded_file_status = "{$type}_uploaded_status";
-		$manual_file_status = "{$type}_manual_status";
-		$uploaded_file_error = "{$type}_uploaded_error";
-		$manual_file_error = "{$type}_manual_error";
-
+	foreach ( $types as $type => $data ) {
 		$file_type_string = str_replace( '_', '-', $type );
 
 		if ( $for_network ) {
-			$$uploaded_file_status = get_site_option( "altis_search_package_status_uploaded-{$file_type_string}" );
-			$$manual_file_status = get_site_option( "altis_search_package_status_manual-{$file_type_string}" );
-			$$uploaded_file_error = get_site_option( "altis_search_package_error_uploaded-{$file_type_string}", null );
-			$$manual_file_error = get_site_option( "altis_search_package_error_manual-{$file_type_string}", null );
+			$data['uploaded_file_status'] = get_site_option( "altis_search_package_status_uploaded-{$file_type_string}" );
+			$data['manual_file_status'] = get_site_option( "altis_search_package_status_manual-{$file_type_string}" );
+			$data['uploaded_file_error'] = get_site_option( "altis_search_package_error_uploaded-{$file_type_string}", null );
+			$data['manual_file_error'] = get_site_option( "altis_search_package_error_manual-{$file_type_string}", null );
 		} else {
-			$$uploaded_file_status = get_option( "altis_search_package_status_uploaded-{$file_type_string}" );
-			$$manual_file_status = get_option( "altis_search_package_status_manual-{$file_type_string}" );
-			$$uploaded_file_error = get_option( "altis_search_package_error_uploaded-{$file_type_string}", null );
-			$$manual_file_error = get_option( "altis_search_package_error_manual-{$file_type_string}", null );
+			$data['uploaded_file_status'] = get_option( "altis_search_package_status_uploaded-{$file_type_string}" );
+			$data['manual_file_status'] = get_option( "altis_search_package_status_manual-{$file_type_string}" );
+			$data['uploaded_file_error'] = get_option( "altis_search_package_error_uploaded-{$file_type_string}", null );
+			$data['manual_file_error'] = get_option( "altis_search_package_error_manual-{$file_type_string}", null );
 		}
 
-		$$uploaded_file_var = get_package_path( "uploaded-{$file_type_string}", $for_network );
-		$$manual_file_var = get_package_path( "manual-{$file_type_string}", $for_network );
+		$data['uploaded_file'] = get_package_path( "uploaded-{$file_type_string}", $for_network );
+		$data['manual_file'] = get_package_path( "manual-{$file_type_string}", $for_network );
 
-		$$text_var = '';
-		if ( file_exists( $$manual_file_var ) ) {
+		$data['text'] = '';
+		if ( file_exists( $data['manual_file'] ) ) {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-			$$text_var = file_get_contents( $$manual_file_var );
+			$data['text'] = file_get_contents( $data['manual_file'] );
 		}
 
-		$$file_date_var = false;
-		if ( file_exists( $$uploaded_file_var ) ) {
-			$$file_date_var = filemtime( $$uploaded_file_var );
+		$data['file_date'] = false;
+		if ( file_exists( $data['uploaded_file'] ) ) {
+			$data['file_date'] = filemtime( $data['uploaded_file'] );
 		}
+
+		$types[ $type ] = $data;
 	}
 
 	$did_update = isset( $_GET['did_update'] );
 
 	if ( $for_network ) {
-		$errors = get_site_option( 'altis_search_config_error', false );
+		$errors = get_site_transient( 'altis_search_config_error' );
 	} else {
-		$errors = get_option( 'altis_search_config_error', false );
+		$errors = get_transient( 'altis_search_config_error' );
 	}
 
 	if ( ! empty( $errors ) && is_array( $errors ) ) {

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -108,7 +108,7 @@ function admin_page() {
  * @return string
  */
 function get_packages_dir() : string {
-	$path = '/usr/share/elasticsearch/config/es-packages';
+	$path = WP_CONTENT_DIR . '/uploads/es-packages';
 
 	/**
 	 * Filter the path at which Elasticsearch package files are stored.

--- a/inc/packages/templates/config.php
+++ b/inc/packages/templates/config.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Search Configuration Admin Template.
+ *
+ * @package altis/search
+ */
+
+?>
+<style>
+	.columns { display: flex; flex-wrap: wrap; }
+	.column { flex: 1 1 300px; width: 300px; margin-right: 20px; }
+	.column textarea { width: 100%; }
+	.column pre { background: #fff; border: 1px solid #152a4e; padding: 10px; overflow: auto; }
+	.column ul li { margin-left: 20px; list-style: disc; }
+</style>
+<div class="wrap">
+	<h1><?php esc_html_e( 'Search Configuration', 'altis' ); ?></h1>
+	<p><?php esc_html_e( 'Configure search synonyms here to improve search results.', 'altis' ); ?></p>
+	<?php if ( is_network_admin() ) : ?>
+		<p class="description"><?php esc_html_e( 'These settings will be used as the default for all sites on the network that match the primary site language.', 'altis' ); ?></p>
+	<?php else : ?>
+		<p class="description"><?php esc_html_e( 'These settings will override the network wide settings if set for this site.', 'altis' ); ?></p>
+		<p class="description"><?php esc_html_e( 'Network wide settings are only applied if the primary language matches the language of this site.', 'altis' ); ?></p>
+	<?php endif; ?>
+	<hr />
+	<form action="" method="post" enctype="multipart/form-data">
+		<?php if ( get_locale() === 'ja' ) : ?>
+			<h2><?php esc_html_e( 'User Dictionary', 'altis' ); ?></h2>
+			<div class="columns">
+				<div class="column">
+					<p><?php esc_html_e( 'A user dictionary provides a way to control how words are broken up. If there are compound words or phrases specific to this site that users may search for they can be specified here to increase search relevancy.', 'altis' ); ?></p>
+					<p><?php esc_html_e( 'The syntax for the provided file should be in a CSV format:', 'altis' ); ?></p>
+					<pre><?php esc_html_e( 'text, token 1 ... token n, reading 1 ... reading n, part-of-speech tag', 'altis' ); ?></pre>
+					<p><?php esc_html_e( 'For example', 'altis' ); ?>:</p>
+					<pre>東京スカイツリー,東京 スカイツリー,トウキョウ スカイツリー,カスタム名詞</pre>
+				</div>
+				<div class="column">
+					<h3><label for="user-dictionary-file"><?php esc_html_e( 'File upload', 'altis' ); ?></label></h3>
+					<?php if ( $user_dictionary_file_date ) : ?>
+						<p>
+							<?php
+							echo esc_html( sprintf(
+								// translators: %s is replaced by the file upload date.
+								__( 'Current file uploaded on %s', 'altis' ),
+								gmdate( get_option( 'date_format', 'Y-m-d H:i:s' ), $user_dicitonary_file_date )
+							) );
+							?>
+						</p>
+						<input type="submit" class="components-button is-link is-destructive" name="user-dictionary-remove" value="<?php esc_attr_e( 'Remove user dictionary file', 'altis' ); ?>" />
+					<?php endif; ?>
+					<p>
+						<input type="file" accept="text/plain" id="user-dictionary-file" name="user-dictionary-file" />
+					</p>
+					<h3><label for="user-dictionary-text"><?php esc_html_e( 'Manual entry', 'altis' ); ?></label></h3>
+					<textarea id="user-dictionary-text" name="user-dictionary-text" rows="10" cols="100%"><?php echo esc_textarea( $user_dictionary_text ); ?></textarea>
+					<p>
+						<input type="submit" class="button button-primary" value="<?php esc_attr_e( 'Update user dictionary', 'altis' ); ?>" />
+					</p>
+				</div>
+			</div>
+			<hr />
+		<?php endif; ?>
+		<h2><?php esc_html_e( 'Synonyms' ); ?></h2>
+		<div class="columns">
+			<div class="column">
+				<p><?php esc_html_e( 'Synonyms allow the search index to treat specific words or phrases as equal. This is useful if:', 'altis' ); ?></p>
+				<ul>
+					<li><?php esc_html_e( 'you have a lot of acronyms or other contractions in your content', 'altis' ); ?></li>
+					<li><?php esc_html_e( 'you have terms in the content that do not appear in the dictionary', 'altis' ); ?></li>
+					<li><?php esc_html_e( 'there are common mis-spellings of search terms', 'altis' ); ?></li>
+					<li><?php esc_html_e( 'you have users from different countries who may use different words for the same thing', 'altis' ); ?></li>
+				</ul>
+				<p><?php esc_html_e( 'The syntax for synonyms is as follows:', 'altis' ); ?></p>
+				<pre># <?php esc_html_e( 'Comments are allowed using a hash at the start the line.', 'altis' ); ?></pre>
+				<p><?php esc_html_e( 'Comma separated words or phrases will be treated as equivalent.', 'altis' ); ?></p>
+				<pre>sneakers, trainers, footwear, shoes
+foozball, foosball, table football
+CPU, central processing unit</pre>
+				<p><?php esc_html_e( 'Comma separated words or phrases followed by "=>" will be treated the same as comma separated words or phrases to the right of the "=>" operator.', 'altis' ); ?></p>
+				<pre>i-pod, i pod => ipod
+tent => bivouac, teepee
+sea biscuit, sea biscit => seabiscuit</pre>
+			</div>
+			<div class="column">
+				<h3><label for="synonyms-file"><?php esc_html_e( 'File upload', 'altis' ); ?></label></h3>
+				<p class="description"><?php esc_html_e( 'If you have a large number of synonyms in the order of 1000s a file upload is recommended.' ); ?></p>
+				<?php if ( $synonyms_file_date ) : ?>
+					<p>
+						<?php
+						echo esc_html( sprintf(
+							// translators: %s is replaced by the file upload date.
+							__( 'Current file uploaded on %s' ),
+							gmdate( get_option( 'date_format', 'Y-m-d H:i:s' ), $synonyms_file_date )
+						) );
+						?>
+					</p>
+					<input type="submit" class="components-button is-link is-destructive" name="synonyms-remove" value="<?php esc_attr_e( 'Remove synonyms file', 'altis' ); ?>" />
+				<?php endif; ?>
+				<p>
+					<input type="file" accept="text/plain" id="synonyms-file" name="synonyms-file" />
+				</p>
+				<h3><label for="synonyms-text"><?php esc_html_e( 'Manual entry', 'altis' ); ?></label></h3>
+				<textarea id="synonyms-text" name="synonyms-text" rows="10" cols="100%"><?php echo esc_textarea( $synonyms_text ); ?></textarea>
+				<p>
+					<input type="submit" class="button button-primary" value="<?php esc_attr_e( 'Update synonyms', 'altis' ); ?>" />
+				</p>
+			</div>
+		</div>
+		<hr />
+		<h2><?php esc_html_e( 'Stop Words' ); ?></h2>
+		<div class="columns">
+			<div class="column">
+				<p><?php esc_html_e( 'Stop words are words that are ignored when searching. All supported languages have a default list of common stop words by default however you can add additional words here.', 'altis' ); ?></p>
+				<p><?php esc_html_e( 'Stop words should be provided as a comma separated list:', 'altis' ); ?></p>
+				<pre>it, of, and, the ...</pre>
+			</div>
+			<div class="column">
+				<h3><label for="stopwords-file"><?php esc_html_e( 'File upload', 'altis' ); ?></label></h3>
+				<p class="description"><?php esc_html_e( 'If you have a large number of stop words in the order of 1000s a file upload is recommended.' ); ?></p>
+				<?php if ( $stopwords_file_date ) : ?>
+					<p>
+						<?php
+						echo esc_html( sprintf(
+							// translators: %s is replaced by the file upload date.
+							__( 'Current file uploaded on %s' ),
+							gmdate( get_option( 'date_format', 'Y-m-d H:i:s' ), $stopwords_file_date )
+						) );
+						?>
+					</p>
+					<input type="submit" class="components-button is-link is-destructive" name="stopwords-remove" value="<?php esc_attr_e( 'Remove stop words file', 'altis' ); ?>" />
+				<?php endif; ?>
+				<p>
+					<input type="file" accept="text/plain" id="stopwords-file" name="stopwords-file" />
+				</p>
+				<h3><label for="stopwords-text"><?php esc_html_e( 'Manual entry', 'altis' ); ?></label></h3>
+				<textarea id="stopwords-text" name="stopwords-text" rows="10" cols="100%"><?php echo esc_textarea( $stopwords_text ); ?></textarea>
+				<p>
+					<input type="submit" class="button button-primary" value="<?php esc_attr_e( 'Update stop words', 'altis' ); ?>" />
+				</p>
+			</div>
+		</div>
+		<input type="hidden" name="action" value="altis-search-config" />
+		<?php wp_nonce_field( 'altis-search-config', '_altisnonce' ); ?>
+	</form>
+</div>

--- a/inc/packages/templates/config.php
+++ b/inc/packages/templates/config.php
@@ -12,7 +12,7 @@
 		<?php if ( empty( $errors ) ) : ?>
 			<div class="notice notice-success is-dismissible">
 				<p><?php esc_html_e( 'Search configuration updated!', 'altis' ); ?></p>
-				<p><?php esc_html_e( 'Updates can take a few moments to propagate fully.', 'altis' ); ?></p>
+				<p><?php esc_html_e( 'Updates can take a few minutes to propagate fully.', 'altis' ); ?></p>
 			</div>
 		<?php else : ?>
 			<?php foreach ( $errors as $error ) : ?>
@@ -44,16 +44,19 @@
 				<div class="column">
 					<h3>
 						<label for="user-dictionary-file"><?php esc_html_e( 'File upload', 'altis' ); ?></label>
-						<?php if ( $user_dictionary_file_date && $user_dictionary_uploaded_status ) : ?>
-							<span class="es-package-status es-package-status--<?php echo esc_attr( strtolower( $user_dictionary_uploaded_status ) ); ?>">
-								<?php esc_html_e( 'Status', 'altis' ); ?>: <?php echo esc_html( $user_dictionary_uploaded_status ); ?>
+						<?php if ( $types['user_dictionary']['file_date'] && $types['user_dictionary']['uploaded_status'] ) : ?>
+							<span class="es-package-status es-package-status--<?php echo esc_attr( strtolower( $types['user_dictionary']['uploaded_status'] ) ); ?>">
+								<?php
+									// translators: %s replaced by status name e.g. 'ACTIVE', 'ERROR'.
+									echo esc_html( sprintf( __( 'Status: %s', 'altis' ), $types['user_dictionary']['uploaded_status'] ) );
+								?>
 							</span>
 						<?php endif; ?>
 					</h3>
-					<?php if ( $user_dictionary_file_date ) : ?>
-						<?php if ( $user_dictionary_uploaded_error ) : ?>
+					<?php if ( $types['user_dictionary']['file_date'] ) : ?>
+						<?php if ( $types['user_dictionary']['uploaded_error'] ) : ?>
 							<div class="notice notice-error">
-								<p><?php echo esc_html( $user_dictionary_uploaded_error ); ?></p>
+								<p><?php echo esc_html( $types['user_dictionary']['uploaded_error'] ); ?></p>
 							</div>
 						<?php endif; ?>
 						<p>
@@ -61,7 +64,7 @@
 							echo esc_html( sprintf(
 								// translators: %s is replaced by the file upload date.
 								__( 'Current file uploaded on %s', 'altis' ),
-								gmdate( get_option( 'date_format', 'Y-m-d H:i:s' ), $user_dictionary_file_date )
+								gmdate( get_option( 'date_format', 'Y-m-d H:i:s' ), $types['user_dictionary']['file_date'] )
 							) );
 							?>
 						</p>
@@ -101,17 +104,20 @@ sea biscuit, sea biscit => seabiscuit</pre>
 			<div class="column">
 				<h3>
 					<label for="synonyms-file"><?php esc_html_e( 'File upload', 'altis' ); ?></label>
-					<?php if ( $synonyms_file_date && $synonyms_uploaded_status ) : ?>
-						<span class="es-package-status es-package-status--<?php echo esc_attr( strtolower( $synonyms_uploaded_status ) ); ?>">
-							<?php esc_html_e( 'Status', 'altis' ); ?>: <?php echo esc_html( $synonyms_uploaded_status ); ?>
+					<?php if ( $types['synonyms']['file_date'] && $types['synonyms']['uploaded_status'] ) : ?>
+						<span class="es-package-status es-package-status--<?php echo esc_attr( strtolower( $types['synonyms']['uploaded_status'] ) ); ?>">
+							<?php
+								// translators: %s replaced by status name e.g. 'ACTIVE', 'ERROR'.
+								echo esc_html( sprintf( __( 'Status: %s', 'altis' ), $types['synonyms']['uploaded_status'] ) );
+							?>
 						</span>
 					<?php endif; ?>
 				</h3>
 				<p class="description"><?php esc_html_e( 'If you have a large number of synonyms in the order of 1000s a file upload is recommended.' ); ?></p>
-				<?php if ( $synonyms_file_date ) : ?>
-					<?php if ( $synonyms_uploaded_error ) : ?>
+				<?php if ( $types['synonyms']['file_date'] ) : ?>
+					<?php if ( $types['synonyms']['uploaded_error'] ) : ?>
 						<div class="notice notice-error">
-							<p><?php echo esc_html( $synonyms_uploaded_error ); ?></p>
+							<p><?php echo esc_html( $types['synonyms']['uploaded_error'] ); ?></p>
 						</div>
 					<?php endif; ?>
 					<p>
@@ -119,7 +125,7 @@ sea biscuit, sea biscit => seabiscuit</pre>
 						echo esc_html( sprintf(
 							// translators: %s is replaced by the file upload date.
 							__( 'Current file uploaded on %s' ),
-							gmdate( get_option( 'date_format', 'Y-m-d H:i:s' ), $synonyms_file_date )
+							gmdate( get_option( 'date_format', 'Y-m-d H:i:s' ), $types['synonyms']['file_date'] )
 						) );
 						?>
 					</p>
@@ -130,18 +136,21 @@ sea biscuit, sea biscit => seabiscuit</pre>
 				</p>
 				<h3>
 					<label for="synonyms-text"><?php esc_html_e( 'Manual entry', 'altis' ); ?></label>
-					<?php if ( $synonyms_manual_status ) : ?>
-						<span class="es-package-status es-package-status--<?php echo esc_attr( strtolower( $synonyms_manual_status ) ); ?>">
-							<?php esc_html_e( 'Status', 'altis' ); ?>: <?php echo esc_html( $synonyms_manual_status ); ?>
+					<?php if ( $types['synonyms']['manual_status'] ) : ?>
+						<span class="es-package-status es-package-status--<?php echo esc_attr( strtolower( $types['synonyms']['manual_status'] ) ); ?>">
+							<?php
+								// translators: %s replaced by status name e.g. 'ACTIVE', 'ERROR'.
+								echo esc_html( sprintf( __( 'Status: %s', 'altis' ), $types['synonyms']['manual_status'] ) );
+							?>
 						</span>
 					<?php endif; ?>
 				</h3>
-				<?php if ( $synonyms_manual_error ) : ?>
+				<?php if ( $types['synonyms']['manual_error'] ) : ?>
 					<div class="notice notice-error">
-						<p><?php echo esc_html( $synonyms_manual_error ); ?></p>
+						<p><?php echo esc_html( $types['synonyms']['manual_error'] ); ?></p>
 					</div>
 				<?php endif; ?>
-				<textarea id="synonyms-text" name="synonyms-text" rows="10" cols="100%"><?php echo esc_textarea( $synonyms_text ); ?></textarea>
+				<textarea id="synonyms-text" name="synonyms-text" rows="10" cols="100%"><?php echo esc_textarea( $types['synonyms']['text'] ); ?></textarea>
 				<p>
 					<input type="submit" class="button button-primary" value="<?php esc_attr_e( 'Update synonyms', 'altis' ); ?>" />
 				</p>
@@ -160,17 +169,20 @@ please</pre>
 			<div class="column">
 				<h3>
 					<label for="stopwords-file"><?php esc_html_e( 'File upload', 'altis' ); ?></label>
-					<?php if ( $stopwords_file_date && $stopwords_uploaded_status ) : ?>
-						<span class="es-package-status es-package-status--<?php echo esc_attr( strtolower( $stopwords_uploaded_status ) ); ?>">
-							<?php esc_html_e( 'Status', 'altis' ); ?>: <?php echo esc_html( $stopwords_uploaded_status ); ?>
+					<?php if ( $types['stopwords']['file_date'] && $types['stopwords']['uploaded_status'] ) : ?>
+						<span class="es-package-status es-package-status--<?php echo esc_attr( strtolower( $types['stopwords']['uploaded_status'] ) ); ?>">
+							<?php
+								// translators: %s replaced by status name e.g. 'ACTIVE', 'ERROR'.
+								echo esc_html( sprintf( __( 'Status: %s', 'altis' ), $types['stopwords']['uploaded_status'] ) );
+							?>
 						</span>
 					<?php endif; ?>
 				</h3>
 				<p class="description"><?php esc_html_e( 'If you have a large number of stop words in the order of 1000s a file upload is recommended.' ); ?></p>
-				<?php if ( $stopwords_file_date ) : ?>
-					<?php if ( $stopwords_uploaded_error ) : ?>
+				<?php if ( $types['stopwords']['file_date'] ) : ?>
+					<?php if ( $types['stopwords']['uploaded_error'] ) : ?>
 						<div class="notice notice-error">
-							<p><?php echo esc_html( $stopwords_uploaded_error ); ?></p>
+							<p><?php echo esc_html( $types['stopwords']['uploaded_error'] ); ?></p>
 						</div>
 					<?php endif; ?>
 					<p>
@@ -178,7 +190,7 @@ please</pre>
 						echo esc_html( sprintf(
 							// translators: %s is replaced by the file upload date.
 							__( 'Current file uploaded on %s' ),
-							gmdate( get_option( 'date_format', 'Y-m-d H:i:s' ), $stopwords_file_date )
+							gmdate( get_option( 'date_format', 'Y-m-d H:i:s' ), $types['stopwords']['file_date'] )
 						) );
 						?>
 					</p>
@@ -189,18 +201,21 @@ please</pre>
 				</p>
 				<h3>
 					<label for="stopwords-text"><?php esc_html_e( 'Manual entry', 'altis' ); ?></label>
-					<?php if ( $stopwords_manual_status ) : ?>
-						<span class="es-package-status es-package-status--<?php echo esc_attr( strtolower( $stopwords_manual_status ) ); ?>">
-							<?php esc_html_e( 'Status', 'altis' ); ?>: <?php echo esc_html( $stopwords_manual_status ); ?>
+					<?php if ( $types['stopwords']['manual_status'] ) : ?>
+						<span class="es-package-status es-package-status--<?php echo esc_attr( strtolower( $types['stopwords']['manual_status'] ) ); ?>">
+							<?php
+								// translators: %s replaced by status name e.g. 'ACTIVE', 'ERROR'.
+								echo esc_html( sprintf( __( 'Status: %s', 'altis' ), $types['stopwords']['manual_status'] ) );
+							?>
 						</span>
 					<?php endif; ?>
 				</h3>
-				<?php if ( $stopwords_manual_error ) : ?>
+				<?php if ( $types['stopwords']['manual_error'] ) : ?>
 					<div class="notice notice-error">
-						<p><?php echo esc_html( $stopwords_manual_error ); ?></p>
+						<p><?php echo esc_html( $types['stopwords']['manual_error'] ); ?></p>
 					</div>
 				<?php endif; ?>
-				<textarea id="stopwords-text" name="stopwords-text" rows="10" cols="100%"><?php echo esc_textarea( $stopwords_text ); ?></textarea>
+				<textarea id="stopwords-text" name="stopwords-text" rows="10" cols="100%"><?php echo esc_textarea( $types['stopwords']['text'] ); ?></textarea>
 				<p>
 					<input type="submit" class="button button-primary" value="<?php esc_attr_e( 'Update stop words', 'altis' ); ?>" />
 				</p>

--- a/inc/packages/templates/config.php
+++ b/inc/packages/templates/config.php
@@ -42,7 +42,7 @@
 							echo esc_html( sprintf(
 								// translators: %s is replaced by the file upload date.
 								__( 'Current file uploaded on %s', 'altis' ),
-								gmdate( get_option( 'date_format', 'Y-m-d H:i:s' ), $user_dicitonary_file_date )
+								gmdate( get_option( 'date_format', 'Y-m-d H:i:s' ), $user_dictionary_file_date )
 							) );
 							?>
 						</p>

--- a/inc/packages/templates/config.php
+++ b/inc/packages/templates/config.php
@@ -91,7 +91,7 @@
 					<li><?php esc_html_e( 'you have users from different countries who may use different words for the same thing', 'altis' ); ?></li>
 				</ul>
 				<p><?php esc_html_e( 'The syntax for synonyms is as follows:', 'altis' ); ?></p>
-				<pre># <?php esc_html_e( 'Comments are allowed using a hash at the start the line.', 'altis' ); ?></pre>
+				<pre><?php esc_html_e( '# Comments are allowed using a hash at the start the line.', 'altis' ); ?></pre>
 				<p><?php esc_html_e( 'Comma separated words or phrases will be treated as equivalent.', 'altis' ); ?></p>
 				<pre>sneakers, trainers, footwear, shoes
 foozball, foosball, table football

--- a/inc/packages/templates/config.php
+++ b/inc/packages/templates/config.php
@@ -6,16 +6,6 @@
  */
 
 ?>
-<style>
-	.columns { display: flex; flex-wrap: wrap; }
-	.column { flex: 1 1 300px; width: 300px; margin-right: 20px; }
-	.column textarea { width: 100%; }
-	.column pre { background: #fff; border: 1px solid #152a4e; padding: 10px; overflow: auto; }
-	.column ul li { margin-left: 20px; list-style: disc; }
-	.es-package-status { float: right; text-transform: uppercase; padding: 2px 5px; font-size: 65%; border-radius: 3px; background: #152a4e; color: #fff; }
-	.es-package-status--active { background-color: #3FCF8E; color: #000; }
-	.es-package-status[class*="error"] { background-color: #ED7B9D; color: #152a4e; }
-</style>
 <div class="wrap">
 	<h1><?php esc_html_e( 'Search Configuration', 'altis' ); ?></h1>
 	<?php if ( $did_update ) : ?>

--- a/inc/packages/templates/config.php
+++ b/inc/packages/templates/config.php
@@ -109,8 +109,10 @@ sea biscuit, sea biscit => seabiscuit</pre>
 		<div class="columns">
 			<div class="column">
 				<p><?php esc_html_e( 'Stop words are words that are ignored when searching. All supported languages have a default list of common stop words by default however you can add additional words here.', 'altis' ); ?></p>
-				<p><?php esc_html_e( 'Stop words should be provided as a comma separated list:', 'altis' ); ?></p>
-				<pre>it, of, and, the ...</pre>
+				<p><?php esc_html_e( 'Stop words should be provided one per line for example:', 'altis' ); ?></p>
+				<pre>ignore
+me
+please</pre>
 			</div>
 			<div class="column">
 				<h3><label for="stopwords-file"><?php esc_html_e( 'File upload', 'altis' ); ?></label></h3>

--- a/inc/packages/templates/config.php
+++ b/inc/packages/templates/config.php
@@ -12,8 +12,9 @@
 	.column textarea { width: 100%; }
 	.column pre { background: #fff; border: 1px solid #152a4e; padding: 10px; overflow: auto; }
 	.column ul li { margin-left: 20px; list-style: disc; }
-	.es-package-status { float: right; text-transform: uppercase; padding: 3px; font-size: 70%; border-radius: 3px; background: #152a4e; color: #fff; }
-	.es-package-status--active { background-color: green; }
+	.es-package-status { float: right; text-transform: uppercase; padding: 2px 5px; font-size: 65%; border-radius: 3px; background: #152a4e; color: #fff; }
+	.es-package-status--active { background-color: #3FCF8E; color: #000; }
+	.es-package-status[class*="error"] { background-color: #ED7B9D; color: #152a4e; }
 </style>
 <div class="wrap">
 	<h1><?php esc_html_e( 'Search Configuration', 'altis' ); ?></h1>
@@ -54,8 +55,8 @@
 					<h3>
 						<label for="user-dictionary-file"><?php esc_html_e( 'File upload', 'altis' ); ?></label>
 						<?php if ( $user_dictionary_file_date && $user_dictionary_uploaded_status ) : ?>
-							<span class="es-package-status es-package-status--<?php echo esc_attr( $user_dictionary_uploaded_status ); ?>">
-								<?php esc_html__( 'Status', 'altis' ); ?>: <?php echo esc_html( $user_dictionary_uploaded_status ); ?>
+							<span class="es-package-status es-package-status--<?php echo esc_attr( strtolower( $user_dictionary_uploaded_status ) ); ?>">
+								<?php esc_html_e( 'Status', 'altis' ); ?>: <?php echo esc_html( $user_dictionary_uploaded_status ); ?>
 							</span>
 						<?php endif; ?>
 					</h3>
@@ -111,8 +112,8 @@ sea biscuit, sea biscit => seabiscuit</pre>
 				<h3>
 					<label for="synonyms-file"><?php esc_html_e( 'File upload', 'altis' ); ?></label>
 					<?php if ( $synonyms_file_date && $synonyms_uploaded_status ) : ?>
-						<span class="es-package-status es-package-status--<?php echo esc_attr( $synonyms_uploaded_status ); ?>">
-							<?php esc_html__( 'Status', 'altis' ); ?>: <?php echo esc_html( $synonyms_uploaded_status ); ?>
+						<span class="es-package-status es-package-status--<?php echo esc_attr( strtolower( $synonyms_uploaded_status ) ); ?>">
+							<?php esc_html_e( 'Status', 'altis' ); ?>: <?php echo esc_html( $synonyms_uploaded_status ); ?>
 						</span>
 					<?php endif; ?>
 				</h3>
@@ -140,8 +141,8 @@ sea biscuit, sea biscit => seabiscuit</pre>
 				<h3>
 					<label for="synonyms-text"><?php esc_html_e( 'Manual entry', 'altis' ); ?></label>
 					<?php if ( $synonyms_manual_status ) : ?>
-						<span class="es-package-status es-package-status--<?php echo esc_attr( $synonyms_manual_status ); ?>">
-							<?php esc_html__( 'Status', 'altis' ); ?>: <?php echo esc_html( $synonyms_manual_status ); ?>
+						<span class="es-package-status es-package-status--<?php echo esc_attr( strtolower( $synonyms_manual_status ) ); ?>">
+							<?php esc_html_e( 'Status', 'altis' ); ?>: <?php echo esc_html( $synonyms_manual_status ); ?>
 						</span>
 					<?php endif; ?>
 				</h3>
@@ -170,8 +171,8 @@ please</pre>
 				<h3>
 					<label for="stopwords-file"><?php esc_html_e( 'File upload', 'altis' ); ?></label>
 					<?php if ( $stopwords_file_date && $stopwords_uploaded_status ) : ?>
-						<span class="es-package-status es-package-status--<?php echo esc_attr( $stopwords_uploaded_status ); ?>">
-							<?php esc_html__( 'Status', 'altis' ); ?>: <?php echo esc_html( $stopwords_uploaded_status ); ?>
+						<span class="es-package-status es-package-status--<?php echo esc_attr( strtolower( $stopwords_uploaded_status ) ); ?>">
+							<?php esc_html_e( 'Status', 'altis' ); ?>: <?php echo esc_html( $stopwords_uploaded_status ); ?>
 						</span>
 					<?php endif; ?>
 				</h3>
@@ -199,8 +200,8 @@ please</pre>
 				<h3>
 					<label for="stopwords-text"><?php esc_html_e( 'Manual entry', 'altis' ); ?></label>
 					<?php if ( $stopwords_manual_status ) : ?>
-						<span class="es-package-status es-package-status--<?php echo esc_attr( $stopwords_manual_status ); ?>">
-							<?php esc_html__( 'Status', 'altis' ); ?>: <?php echo esc_html( $stopwords_manual_status ); ?>
+						<span class="es-package-status es-package-status--<?php echo esc_attr( strtolower( $stopwords_manual_status ) ); ?>">
+							<?php esc_html_e( 'Status', 'altis' ); ?>: <?php echo esc_html( $stopwords_manual_status ); ?>
 						</span>
 					<?php endif; ?>
 				</h3>

--- a/inc/packages/templates/config.php
+++ b/inc/packages/templates/config.php
@@ -15,6 +15,20 @@
 </style>
 <div class="wrap">
 	<h1><?php esc_html_e( 'Search Configuration', 'altis' ); ?></h1>
+	<?php if ( $did_update ) : ?>
+		<?php if ( empty( $errors ) ) : ?>
+			<div class="notice notice-success is-dismissible">
+				<p><?php esc_html_e( 'Search configuration updated!', 'altis' ); ?></p>
+				<p><?php esc_html_e( 'Updates can take a few moments to propagate fully.', 'altis' ); ?></p>
+			</div>
+		<?php else : ?>
+			<?php foreach ( $errors as $error ) : ?>
+				<div class="notice notice-error is-dismissible">
+					<p><?php echo esc_html( $error->get_error_message() ); ?></p>
+				</div>
+			<?php endforeach; ?>
+		<?php endif; ?>
+	<?php endif; ?>
 	<p><?php esc_html_e( 'Configure search synonyms here to improve search results.', 'altis' ); ?></p>
 	<?php if ( is_network_admin() ) : ?>
 		<p class="description"><?php esc_html_e( 'These settings will be used as the default for all sites on the network that match the primary site language.', 'altis' ); ?></p>

--- a/inc/packages/templates/config.php
+++ b/inc/packages/templates/config.php
@@ -51,8 +51,6 @@
 					<p>
 						<input type="file" accept="text/plain" id="user-dictionary-file" name="user-dictionary-file" />
 					</p>
-					<h3><label for="user-dictionary-text"><?php esc_html_e( 'Manual entry', 'altis' ); ?></label></h3>
-					<textarea id="user-dictionary-text" name="user-dictionary-text" rows="10" cols="100%"><?php echo esc_textarea( $user_dictionary_text ); ?></textarea>
 					<p>
 						<input type="submit" class="button button-primary" value="<?php esc_attr_e( 'Update user dictionary', 'altis' ); ?>" />
 					</p>


### PR DESCRIPTION
Adds a network admin and site admin settings page to upload or manually enter a user dictionary, stop words and synonyms.

Still to do:

- [x] Test with local environments, docker & chassis
- [x] Test AWS Elasticsearch Service integration
- [x] Filter ES mapping to:
  - Add user dictionary to kuromoji tokenizer
  - Add stop words filters for manual & uploaded to default analyzer
  - Add synonyms filters for manual & uploaded to default analyzer
  - Support network wide override for sites with same language
- [x] Handle reindexing on update using `_update_by_query` ES endpoint

See #32.