### PR TITLE
Use the custom kuromoji tokenizer

### DIFF
--- a/inc/analyzers.json
+++ b/inc/analyzers.json
@@ -858,7 +858,7 @@
 				"greek_lowercase_filter",
 				"cjk_width"
 			],
-			"tokenizer": "kuromoji_tokenizer"
+			"tokenizer": "kuromoji"
 		},
 		"ko_analyzer": {
 			"type": "cjk",


### PR DESCRIPTION
This was set to use the default tokenizer instead of our custom one with the search mode option set