### PR TITLE
Remove protected content config option

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,7 +65,6 @@ The following options can be enabled/disabled via the search configuration.
 - `"woocommerce": true|false (default)`
 - `"autosuggest": true|false (default)`
 - `"index-documents": true (default) |false`
-- `"protected-content": true (default) |false`
 
 ### Related Posts
 To find related posts leveraging Elastic Search use the `ep_find_related()` function. The function requires a single parameter ( `$post_id` ) with another optional parameter ( `$return` ). The `$post_id` will be used to find the posts that are related to it, with `$return` specifying the number of related posts to return, which defaults to 5.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -342,7 +342,10 @@ function override_elasticpress_feature_activation( bool $is_active, array $setti
 		'facets' => (bool) ( $config['facets'] ?? false ),
 		'woocommerce' => (bool) ( $config['woocommerce'] ?? false ),
 		'autosuggest' => (bool) ( $config['autosuggest'] ?? false ),
-		'protected_content' => (bool) ( $config['protected-content'] ?? true ),
+		// Force protected content feature off as we're overriding indexable types & statuses anyway.
+		// Enabling this feature causes all WP_Query calls for protected content post types to use
+		// Elasticsearch, even if not performing a search.
+		'protected_content' => false,
 	];
 
 	if ( ! isset( $features_activated[ $feature->slug ] ) ) {

--- a/load.php
+++ b/load.php
@@ -18,7 +18,6 @@ add_action( 'altis.modules.init', function () {
 		'woocommerce' => false,
 		'autosuggest' => false,
 		'slowlog_thresholds' => true,
-		'protected-content' => true,
 		'mode' => 'simple',
 		'strict' => true,
 		'field-boost' => [],


### PR DESCRIPTION
We are rolling our own version of protected content - allowing everything to be indexed by overriding the indexable post types and statuses. This prevents unwated ElasticPress behaviour whereby even non search queries would be sent to Elasticsearch.

This was a regression in the v4.0.0 release.