### PR TITLE
Improve ElasticPress v3 support

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -329,6 +329,8 @@ function filter_index_name( string $index ) : string {
 		$old_index = str_replace( '-post', '', $index );
 		if ( Elasticsearch::factory()->index_exists( $old_index ) ) {
 			return $old_index;
+		} else {
+			set_index_version( 3 );
 		}
 	}
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -337,7 +337,10 @@ function filter_index_name( string $index ) : string {
  *
  * @return string
  */
-function filter_documents_pipeline_id() : string {
+function filter_documents_pipeline_id( string $id ) : string {
+	if ( ! get_index_version() ) {
+		return $id;
+	}
 	return 'attachments';
 }
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -273,7 +273,8 @@ function on_wp_install() {
 }
 
 /**
- * When an existing index is deleted set the index version so
+ * Set the index version to match ElasticPress version when
+ * indexes are deleted.
  *
  * @param array $query The Elasticsearch query.
  * @param string|null $type The remote request type.
@@ -300,8 +301,9 @@ function set_index_version( int $version ) {
 }
 
 /**
- * Get the index version for the current site. Defaults to
- * 2 for ElasticPress version 2.
+ * Get the index version for the current site.
+ *
+ * Defaults to 2 for ElasticPress version 2.
  *
  * @return int
  */
@@ -310,6 +312,8 @@ function get_index_version() : int {
 }
 
 /**
+ * Modify default index names.
+ *
  * ElasticPress adds the indexable object type to index names. We can maintain backwards
  * compatibility by filtering the posts indexable index name to remove this type.
  *
@@ -333,6 +337,8 @@ function filter_index_name( string $index ) : string {
 }
 
 /**
+ * Modify the documents ingest pipeline ID.
+ *
  * The documents ingest pipeline does not need to be site specific
  * as it is always the same.
  *

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -575,7 +575,7 @@ function setup_elasticpress_on_install() {
 		'return' => true,
 	] );
 	WP_CLI::line( $response );
-	WP_CLI::line( WP_CLI::colorize( "%GElasticPress configured.%n" ) );
+	WP_CLI::line( WP_CLI::colorize( '%GElasticPress configured.%n' ) );
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -438,6 +438,8 @@ function override_elasticpress_feature_activation( bool $is_active, array $setti
 		// Enabling this feature causes all WP_Query calls for protected content post types to use
 		// Elasticsearch, even if not performing a search.
 		'protected_content' => false,
+		'terms' => true,
+		'users' => true,
 	];
 
 	if ( ! isset( $features_activated[ $feature->slug ] ) ) {


### PR DESCRIPTION
This update integrates Altis a little better with ElasticPress v3 in the following ways:

- Ensure ElasticPress won't accidentally delete indexes it doesn't control eg. analytics or .kibana
- Set the posts index name to the same name used in ElasticPress v2 for back compat