### PR TITLE
Add ability to register fields for autocompletion

### DIFF
--- a/inc/analyzers.json
+++ b/inc/analyzers.json
@@ -116,7 +116,7 @@
 		},
 		"en_stem_filter": {
 			"type": "stemmer",
-			"name": "minimal_english"
+			"name": "light_english"
 		},
 		"es_stop_filter": {
 			"type": "stop",
@@ -972,6 +972,15 @@
 				"icu_folding"
 			],
 			"tokenizer": "icu_tokenizer"
+		},
+		"edge_ngram_analyzer": {
+			"type": "custom",
+			"tokenizer": "icu_tokenizer",
+			"filter": [
+				"icu_normalizer",
+				"icu_folding",
+				"edge_ngram"
+			]
 		}
 	},
 	"tokenizer": {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -616,6 +616,7 @@ function elasticpress_mapping( array $mapping ) : array {
 
 	// Add autosuggest ngram analyzer by default, used for attachment search.
 	$autosuggest_fields = get_autosuggest_fields();
+	$search_analyzer = ! empty( $mapping['settings']['analysis']['analyzer']['default_search'] ) ? 'default_search' : 'default';
 	foreach ( $autosuggest_fields as $type => $fields ) {
 		foreach ( $fields as $field ) {
 			if ( ! isset( $mapping['mappings'][ $type ]['properties'][ $field ] ) ) {
@@ -627,6 +628,7 @@ function elasticpress_mapping( array $mapping ) : array {
 			$mapping['mappings'][ $type ]['properties'][ $field ]['fields']['suggest'] = [
 				'type' => 'text',
 				'analyzer' => 'edge_ngram_analyzer',
+				'search_analyzer' => $search_analyzer,
 			];
 		}
 	}
@@ -794,8 +796,7 @@ function get_autosuggest_fields( ?string $type = null ) : array {
 		/**
 		 * Filter the fields to use for autosuggest search behaviour.
 		 *
-		 * @param array $fields The field names to include in autosuggestions.
-		 * @param array $args The WP_Query args.
+		 * @param array $fields The field names for a specific type to include in autosuggestions.
 		 */
 		$fields = apply_filters( "altis.search.autosuggest_{$type}_fields", $fields[ $type ] );
 	}


### PR DESCRIPTION
This requires extending the mapping and how documents are analysed at index time so there is an increase in the index size. This however enables the ability to provide autosuggestions and to match partial search phrases. This is useful for autosuggest dropdowns or dynamic searches that update as you type such as in the media library.