### PR TITLE
Ensure EP is loaded before upgrade routine

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -28,7 +28,7 @@ use WP_Query;
  * @return void
  */
 function bootstrap() {
-	add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_elasticpress', 9 );
+	add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_elasticpress', 4 );
 	add_filter( 'altis_healthchecks', __NAMESPACE__ . '\\add_elasticsearch_healthcheck' );
 
 	// Load debug bar for ElasticPress if Query Monitor is enabled in the config.


### PR DESCRIPTION
ElasticPress runs an upgrade routine (setting some options etc) on `plugin_loaded` at priority 5 so we need to load it before that runs to ensure everything is how the plugin expects it to be.