### PR TITLE
Add synonyms and stopwords before icu_folding if present

### DIFF
--- a/inc/analyzers.json
+++ b/inc/analyzers.json
@@ -854,9 +854,7 @@
 				"kuromoji_baseform",
 				"ja_pos_filter",
 				"icu_normalizer",
-				"icu_folding",
-				"greek_lowercase_filter",
-				"cjk_width"
+				"icu_folding"
 			],
 			"tokenizer": "kuromoji"
 		},


### PR DESCRIPTION
Fixes #121

`icu_folding` does everything that `icu_normalizer` does except that it also converts accented characters to their base forms. For synonyms we want to avoid case-sensitivity but support properly accented words as written by folks in their given language.

This checks for the presence of `icu_folding` and adds synonyms before it if so, otherwise appending them. It also checks for `icu_normalizer` and ensures stopwords are added directly afterwards if present, otherwise prepending them.