### PR TITLE
Fix default language selection

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -789,7 +789,7 @@ function elasticpress_analyzer_language() : string {
 	 * Get value from db as get_locale() doesn't always return the current
 	 * value when using switch_to_blog().
 	 */
-	$locale = get_option( 'WPLANG', get_site_option( 'WPLANG', 'en_US' ) );
+	$locale = get_option( 'WPLANG', get_site_option( 'WPLANG' ) ) ?: 'en_US';
 	$locale = strtolower( $locale );
 	if ( isset( $supported_languages[ $locale ] ) ) {
 		return $supported_languages[ $locale ];


### PR DESCRIPTION
Apparently the `WPLANG` option no longer reliably returns a value so we need to fall back to `en_US` with a compact ternary instead.

This update will only applied during a reindex.

Fixes #156