### PR TITLE
Fix ES fallback no-op

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -306,7 +306,7 @@ function log_remote_request_errors( array $request, ?string $type = null ) {
  * Default ElasticPress functionality is to fall-back to MySQL search when queries fail. We want to instead
  * no-op the query when this happens, as we don't want to put lots of load on to MySQL.
  *
- * @param array $posts
+ * @param ?array $posts List of posts or null if request failed.
  * @param WP_Query $query The current query object.
  * @return array
  */

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -76,8 +76,10 @@ function load_elasticpress() {
 		return set_url_scheme( $url, ELASTICSEARCH_PORT === 443 ? 'https' : 'http' );
 	});
 	add_action( 'ep_remote_request', __NAMESPACE__ . '\\log_remote_request_errors', 10, 2 );
-	add_filter( 'posts_request', __NAMESPACE__ . '\\noop_wp_query_on_failed_ep_request', 11, 2 );
-	add_filter( 'found_posts_query', __NAMESPACE__ . '\\noop_wp_query_on_failed_ep_request', 6, 2 );
+
+	// Noop queries that tried to use ES, but failed. Priority 11 to be after ElasticPress.
+	add_filter( 'posts_pre_query', __NAMESPACE__ . '\\noop_wp_query_on_failed_ep_request', 11, 2 );
+
 	add_filter( 'ep_admin_wp_query_integration', '__return_true' );
 	add_filter( 'ep_ajax_wp_query_integration', '__return_true' );
 	add_filter( 'ep_indexable_post_status', __NAMESPACE__ . '\\get_elasticpress_indexable_post_statuses' );
@@ -304,31 +306,16 @@ function log_remote_request_errors( array $request, ?string $type = null ) {
  * Default ElasticPress functionality is to fall-back to MySQL search when queries fail. We want to instead
  * no-op the query when this happens, as we don't want to put lots of load on to MySQL.
  *
- * @param string $request SQL query string.
+ * @param array $posts
  * @param WP_Query $query The current query object.
- * @return string
+ * @return array
  */
-function noop_wp_query_on_failed_ep_request( string $request, WP_Query $query ) : string {
-	if ( ! isset( $query->elasticsearch_success ) || $query->elasticsearch_success === true ) {
-		return $request;
+function noop_wp_query_on_failed_ep_request( $posts, WP_Query $query ) : ?array {
+	if ( $posts === null && $query->elasticsearch_success === false ) {
+		return [];
 	}
 
-	global $wpdb;
-	return "SELECT * FROM $wpdb->posts WHERE 1=0";
-}
-
-/**
- * No-op found rows query if ElasticSearch request fails.
- *
- * @param string $sql SQL query string.
- * @param WP_Query $query The current query object.
- * @return string
- */
-function noop_wp_query_found_rows_on_failed_ep_request( string $sql, WP_Query $query ) : string {
-	if ( ! isset( $query->elasticsearch_success ) || $query->elasticsearch_success === true ) {
-		return $sql;
-	}
-	return '';
+	return $posts;
 }
 
 /**


### PR DESCRIPTION
Currently the no-op failed ES queries is not working. This is because the old method of hooking in to `posts_request` filter, checking for `elasticsearch_success`, and returning an empty SQL query string (or well, a SELECT that doesn't match anything). At some point (maybe EP 3), ElasticPress now hooks into `posts_pre_query` which is _after_ `posts_request`, in which case the `elasticsearch_success` is never present.

A better approach is to hook into `posts_pre_query` just after ElasticPress and set the matches posts to an empty array if the EP request just failed.
