### PR TITLE
Check for a package ID before checking file exists

### DIFF
--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -237,6 +237,15 @@ function get_package_id( string $slug, bool $for_network = false ) : ?string {
 	 */
 	$package_id = apply_filters( 'altis.search.get_package_id', $package_id, $slug, $for_network );
 
+	// Check package file exists.
+	// In cases where a database has been imported the package file may not exist
+	// for the current stack so we apply a fail safe here.
+	$package_path = get_package_path( $slug, $for_network );
+	if ( ! empty( $package_id ) && ! file_exists( $package_path ) ) {
+		trigger_error( sprintf( 'Referenced package file "%s" does not exist.', $package_path ), E_USER_WARNING );
+		return null;
+	}
+
 	return $package_id;
 }
 


### PR DESCRIPTION
This was resulting in useless warnings when checking for non existent package IDs so we check for the file existing after getting a valid package ID instead.

This is a better fix for #181 