### PR TITLE
Limit search queries to 100 characters

### DIFF
--- a/docs/search-configuration/README.md
+++ b/docs/search-configuration/README.md
@@ -141,7 +141,7 @@ This option allows you to prevent transpositions from being counted as a single 
 
 ## Max Query Length
 
-Typically search queries can be as long as the user wishes. As a preventative measure against slow queries and search request spamming Altis limits search query strings to **80 characters** by default.
+Typically search queries can be as long as the user wishes. As a preventative measure against very slow queries and search request spamming Altis limits search query strings to **100 characters** by default.
 
 You can configure this value in 2 ways.
 
@@ -153,7 +153,7 @@ Using the Altis Search config option `max-query-length`:
 		"altis": {
 			"modules": {
 				"search": {
-					"max-query-length": 100
+					"max-query-length": 150
 				}
 			}
 		}
@@ -163,10 +163,20 @@ Using the Altis Search config option `max-query-length`:
 
 Using the filter `altis.search.max_query_length`:
 
+Note that the filter method will take precedence and can be used for applying conditional logic.
+
 ```php
-add_filter( 'altis.search.max_query_length', function () {
-	return 100;
+add_filter( 'altis.search.max_query_length', function ( int $max_length, string $search ) {
+	// Allow long search strings in the admin.
+	if ( is_admin() ) {
+		return 1000;
+	}
+
+	// Allow long search queries if they are URLs.
+	if ( preg_match( '#https?://[a-z0-9/_-.]+#', $search ) ) {
+		return mb_strlen( $search );
+	}
+
+	return 50;
 } );
 ```
-
-covid+vaccines+caused+more+deaths+than+all+other+vaccines+combined

--- a/docs/search-configuration/README.md
+++ b/docs/search-configuration/README.md
@@ -138,3 +138,33 @@ If you have a prefix length of 0 you may wish to increase this value to get more
 **`transpositions`**
 
 This option allows you to prevent transpositions from being counted as a single edit. In the above example the transposition "act" to "cat" has an edit distance of 1. Setting this value to `false` would mean the same transposition would have an edit distance of 2 because 2 letters have been replaced.
+
+## Max Query Length
+
+Typically search queries can be as long as the user wishes. As a preventative measure against slow queries and search request spamming Altis limits search query strings to **50 characters** by default.
+
+You can configure this value in 2 ways.
+
+Using the Altis Search config option `max-query-length`:
+
+```json
+{
+	"extra": {
+		"altis": {
+			"modules": {
+				"search": {
+					"max-query-length": 100
+				}
+			}
+		}
+	}
+}
+```
+
+Using the filter `altis.search.max_query_length`:
+
+```php
+add_filter( 'altis.search.max_query_length', function () {
+	return 100;
+} );
+```

--- a/docs/search-configuration/README.md
+++ b/docs/search-configuration/README.md
@@ -141,7 +141,7 @@ This option allows you to prevent transpositions from being counted as a single 
 
 ## Max Query Length
 
-Typically search queries can be as long as the user wishes. As a preventative measure against slow queries and search request spamming, Altis limits search query strings to **80 characters** by default.
+Typically search queries can be as long as the user wishes. As a preventative measure against slow queries and search request spamming, Altis limits search query strings to **100 characters** by default.
 
 You can configure this value in 2 ways.
 

--- a/docs/search-configuration/README.md
+++ b/docs/search-configuration/README.md
@@ -141,7 +141,7 @@ This option allows you to prevent transpositions from being counted as a single 
 
 ## Max Query Length
 
-Typically search queries can be as long as the user wishes. As a preventative measure against slow queries and search request spamming Altis limits search query strings to **50 characters** by default.
+Typically search queries can be as long as the user wishes. As a preventative measure against slow queries and search request spamming Altis limits search query strings to **80 characters** by default.
 
 You can configure this value in 2 ways.
 
@@ -168,3 +168,5 @@ add_filter( 'altis.search.max_query_length', function () {
 	return 100;
 } );
 ```
+
+covid+vaccines+caused+more+deaths+than+all+other+vaccines+combined

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -127,6 +127,9 @@ function load_elasticpress() {
 	// Ensure non ElasticPress indexes are not affected by global edits using *.
 	add_filter( 'ep_pre_request_url', __NAMESPACE__ . '\\protect_non_ep_indexes', 10, 5 );
 
+	// Limit search query length.
+	add_action( 'pre_get_posts', __NAMESPACE__ . '\\limit_search_query_length', 1000 );
+
 	require_once Altis\ROOT_DIR . '/vendor/10up/elasticpress/elasticpress.php';
 
 	// Now ElasticPress has been included, we can remove some of it's filters.
@@ -1822,4 +1825,34 @@ function handle_autosuggest_endpoint() {
 
 	// Return JSON response.
 	wp_send_json( $data, 200 );
+}
+
+/**
+ * Limit search query string length.
+ *
+ * Prevents overly complex queries that can be slow to process and tie up resources.
+ *
+ * @param WP_Query $query The WP_Query instance (passed by reference).
+ */
+function limit_search_query_length( WP_Query $query ) : void {
+	if ( empty( $query->get( 's' ) ) ) {
+		return;
+	}
+
+	$search = $query->get( 's' );
+
+	// Get max length from config.
+	$max_length = Altis\get_config()['search']['max-query-length'] ?? 50;
+
+	/**
+	 * Filters the maximum allowed query string length for searches.
+	 *
+	 * @param int $max_length The maximum allowed query string length.
+	 */
+	$max_length = (int) apply_filters( 'altis.search.max_query_length', $max_length );
+
+	$search = mb_substr( $search, 0, $max_length );
+	$search = trim( $search );
+
+	$query->set( 's', $search );
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -1842,7 +1842,7 @@ function limit_search_query_length( WP_Query $query ) : void {
 	$search = $query->get( 's' );
 
 	// Get max length from config.
-	$max_length = Altis\get_config()['search']['max-query-length'] ?? 50;
+	$max_length = Altis\get_config()['search']['max-query-length'] ?? 80;
 
 	/**
 	 * Filters the maximum allowed query string length for searches.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -1842,14 +1842,15 @@ function limit_search_query_length( WP_Query $query ) : void {
 	$search = $query->get( 's' );
 
 	// Get max length from config.
-	$max_length = Altis\get_config()['search']['max-query-length'] ?? 80;
+	$max_length = Altis\get_config()['search']['max-query-length'] ?? 100;
 
 	/**
 	 * Filters the maximum allowed query string length for searches.
 	 *
 	 * @param int $max_length The maximum allowed query string length.
+	 * @param string $search The current search term.
 	 */
-	$max_length = (int) apply_filters( 'altis.search.max_query_length', $max_length );
+	$max_length = (int) apply_filters( 'altis.search.max_query_length', $max_length, $search );
 
 	$search = mb_substr( $search, 0, $max_length );
 	$search = trim( $search );


### PR DESCRIPTION
This one will need a little discussion I think on what a reasonable limit is.

This hopefully will prevent spam queries tying up resources for too long with absurdly long search queries.