### PR TITLE
Update searchable fields documentation

### DIFF
--- a/docs/cms-query-integration.md
+++ b/docs/cms-query-integration.md
@@ -43,7 +43,7 @@ Altis will search key content fields by default, including those defined in the 
 
 ### Using Query Parameters
 
-`WP_Query`, `WP_Term_Query` and `WP_User_Query` support a `search_fields` parameter. This can be used override the default searched fields and even to modify how the fields are boosted using the `<field>^<boost value>` syntax.
+`WP_Query`, `WP_Term_Query` and `WP_User_Query` support a `search_fields` parameter. This can be used to override the default searched fields and even to modify how the fields are boosted using the `<field>^<boost value>` syntax.
 
 ```php
 $posts = new WP_Query( [
@@ -56,7 +56,7 @@ $posts = new WP_Query( [
 ] );
 ```
 
-Note that when using the `search_fields` parameter the `ep_search_fields` filter will be run and can modify the end results.
+When using the `search_fields` parameter, the `ep_search_fields` filter will be run which can modify the list of searched fields.
 
 ### Using Filters
 

--- a/docs/posts-index-modification.md
+++ b/docs/posts-index-modification.md
@@ -23,14 +23,3 @@ add_filter( 'ep_post_sync_args_post_prepare_meta', function ( array $post_data, 
 ```
 
 This will mean the searchable data stored in the index will include the country name.
-
-## Searching Additional Data
-
-By default, when using the CMS search APIs such as `WP_Query` only the default search fields will be used, not any additional data stored using the above method. To include posts matching the `country` field, use the `ep_search_fields` hook to include your custom field.
-
-```php
-add_filter( 'ep_search_fields', function ( array $fields ) : array {
-	$fields[] = 'country';
-	return $fields;
-} );
-```


### PR DESCRIPTION
The searchable fields docs are out of date since Altis v5 when ElasticPress added weighting. The `ep_search_fields` filter only works for queries where specific fields have been provided.