### PR TITLE
Prevent EP from checking the db during install

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -133,6 +133,12 @@ function load_elasticpress() {
 	// Limit search query length.
 	add_action( 'pre_get_posts', __NAMESPACE__ . '\\limit_search_query_length', 1000 );
 
+	// Ensure upgrades aren't attempted during install due to db access.
+	if ( defined( 'WP_INITIAL_INSTALL' ) && WP_INITIAL_INSTALL ) {
+		add_filter( 'pre_site_option_ep_version', '__return_false' );
+		add_filter( 'pre_site_option_ep_last_sync', '__return_false' );
+	}
+
 	require_once Altis\ROOT_DIR . '/vendor/10up/elasticpress/elasticpress.php';
 
 	// Now ElasticPress has been included, we can remove some of it's filters.


### PR DESCRIPTION
The new EP version added in Altis v7 broke the installation process by trying to read from the db too early before the tables are created, this fix bypasses the db request during initial install only.