### PR TITLE
[Backport v7-branch] Prevent EP from checking the db during install

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -127,6 +127,12 @@ function load_elasticpress() {
 	// Ensure non ElasticPress indexes are not affected by global edits using *.
 	add_filter( 'ep_pre_request_url', __NAMESPACE__ . '\\protect_non_ep_indexes', 10, 5 );
 
+	// Ensure upgrades aren't attempted during install due to db access.
+	if ( defined( 'WP_INITIAL_INSTALL' ) && WP_INITIAL_INSTALL ) {
+		add_filter( 'pre_site_option_ep_version', '__return_false' );
+		add_filter( 'pre_site_option_ep_last_sync', '__return_false' );
+	}
+
 	require_once Altis\ROOT_DIR . '/vendor/10up/elasticpress/elasticpress.php';
 
 	// Now ElasticPress has been included, we can remove some of it's filters.


### PR DESCRIPTION
Backporting #258


---------------


The new EP version added in Altis v7 broke the installation process by trying to read from the db too early before the tables are created, this fix bypasses the db request during initial install only.