### PR TITLE
[docs] Add a note about Elastic results availability during (re-)index

### DIFF
--- a/docs/reindexing-content.md
+++ b/docs/reindexing-content.md
@@ -14,6 +14,8 @@ wp site list --field=url | xargs -I % wp elasticpress index --url=%
 
 `wp site list --field=url` will print each site URL on a new line and ingested by `xargs` to be processed individually.
 
+**Note:** During the indexing process, the site will not be using Elastic index for searches/queries, so some features like faceting or autosuggest will not work as expected until the reindex process is finished.
+
 To re-sychronise the index and update mappings (needed when the mapping has been modified via filters, site language has been changed or a user dictionary has been added and not reindexed successfully):
 
 ```sh

--- a/docs/reindexing-content.md
+++ b/docs/reindexing-content.md
@@ -14,7 +14,7 @@ wp site list --field=url | xargs -I % wp elasticpress index --url=%
 
 `wp site list --field=url` will print each site URL on a new line and ingested by `xargs` to be processed individually.
 
-**Note:** During the indexing process, the site will not be using Elastic index for searches/queries, so some features like faceting or autosuggest will not work as expected until the reindex process is finished.
+**Note:** During the indexing process, the site will not use the Elasticsearch index for searches/queries, so some features like faceting or autosuggest will not work as expected until the process is finished.
 
 To re-sychronise the index and update mappings (needed when the mapping has been modified via filters, site language has been changed or a user dictionary has been added and not reindexed successfully):
 


### PR DESCRIPTION
This adds a note about the unavailability of Elastic during (re-)index processes, eg: faceting, autosuggest, and the query integration.