### PR TITLE
Use the standard Bengali stemmer

### DIFF
--- a/inc/analysis/namespace.php
+++ b/inc/analysis/namespace.php
@@ -51,8 +51,7 @@ function get_analyzers() : array {
 			],
 			'bn_stem_filter' => [
 				'type' => 'stemmer',
-				// The light_bengali stemmer was removed in Elasticsearch version 7.6.
-				'name' => version_compare( $version, '7.6', '<' ) ? 'light_bengali' : 'bengali',
+				'name' => 'bengali',
 			],
 			'br_stop_filter' => [
 				'type' => 'stop',


### PR DESCRIPTION
Bengali light stemmer is not available in most ES versions, default to standard instead.

Fixes an error putting the mapping when recreating indexes with ES 6.8+.