### PR TITLE
EP dashboard notices not being hidden

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -1164,9 +1164,10 @@ function remove_ep_dashboard_notices( array $notices ) : array {
 		'no_sync',
 		'upgrade_sync',
 		'using_autosuggest_defaults',
+		'es_above_compat',
 	];
 
-	return array_diff( $notices, $hidden );
+	return array_diff_key( $notices, array_flip( $hidden ) );
 }
 
 /**


### PR DESCRIPTION
EP updated the way dashboard notices are structured so we should remove by key instead of direct value.