### PR TITLE
Default to inline index settings

### DIFF
--- a/docs/search-configuration/custom-dictionaries.md
+++ b/docs/search-configuration/custom-dictionaries.md
@@ -10,7 +10,9 @@ User dictionaries can be configured for [the entire network](admin://network/adm
 
 Note that for the user dictionary, manual entries will override any uploaded files. So make sure to use one or the other, not both, unlike what you can do with synonyms and stop words.
 
-By default, Altis uses inline index settings to include all of these dictionaries, however, it is recommended to turn such feature off in case uploaded files are bigger than 100KB for the sake of performance and ES cluster sizes ( see below ). Altis will notify you if your file size exceeds the recommended limit within the configuration page.
+By default, Altis uses inline index settings to include all of these dictionaries, however, it is recommended to turn this feature off in case uploaded files are bigger than 100KB. This helps to improve the performance and ES cluster sizes (see below). Altis will notify you if your file size exceeds the recommended limit within the configuration page.
+
+**Note**: If you do not use inline index settings you will need to manually reindex your content after making changes to synonyms, stopwords or the Japanese user dictionary.
 
 ```json
 {

--- a/docs/search-configuration/custom-dictionaries.md
+++ b/docs/search-configuration/custom-dictionaries.md
@@ -12,7 +12,7 @@ Note that for the user dictionary, manual entries will override any uploaded fil
 
 By default, Altis uses inline index settings to include all of these dictionaries, however, it is recommended to turn such feature off in case uploaded files are bigger than 100KB for the sake of performance and ES cluster sizes ( see below ). Altis will notify you if your file size exceeds the recommended limit within the configuration page.
 
-```
+```json
 {
     "extra": {
         "altis": {

--- a/docs/search-configuration/custom-dictionaries.md
+++ b/docs/search-configuration/custom-dictionaries.md
@@ -2,11 +2,29 @@
 
 The search module supports 3 types of custom dictionaries for helping to tune search results for your content. These are synonyms, stop words and custom text analysis for Japanese.
 
-In the website admin, you can upload text files (`.txt` only) and, in the case of stop words and synonyms, also manually enter them on the [Search Configuration](admin://admin.php?page=search-config) screen.
+In the website admin, you can upload text files (`.txt` only) and/or manually enter them on the [Search Configuration](admin://admin.php?page=search-config) screen.
 
-Note that only a file upload is supported for the Japanese user dictionary, as it is used by the [kuromoji tokenizer](https://www.elastic.co/guide/en/elasticsearch/plugins/6.3/analysis-kuromoji-tokenizer.html) that splits words up during analysis. Synonyms and stop words are "filters" so multiple files (uploaded and manually entered) can be used for those.
+Altis includes support for a Japanese user dictionary to be used by the [kuromoji tokenizer](https://www.elastic.co/guide/en/elasticsearch/plugins/6.3/analysis-kuromoji-tokenizer.html) that splits words up during analysis. Synonyms and stop words are "filters" so multiple files (uploaded and manually entered) can be used for those.
 
 User dictionaries can be configured for [the entire network](admin://network/admin.php?page=search-config) (provided the subsites match the primary site language) or at an individual site level.
+
+Note that for the user dictionary, manual entries will override any uploaded files. So make sure to use one or the other, not both, unlike what you can do with synonyms and stop words.
+
+By default, Altis uses inline index settings to include all of these dictionaries, however, it is recommended to turn such feature off in case uploaded files are bigger than 100KB for the sake of performance and ES cluster sizes ( see below ). Altis will notify you if your file size exceeds the recommended limit within the configuration page.
+
+```
+{
+    "extra": {
+        "altis": {
+            "modules": {
+                "search": {
+                    "inline-index-settings": false
+                }
+            }
+        }
+    }
+}
+```
 
 ## Updating User Dictionaries
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -24,8 +24,6 @@ use WP_REST_Server;
 use WP_Term_Query;
 use WP_User_Query;
 
-use function Altis\Enhanced_Search\Packages\get_package_contents;
-
 const SORTABLE_MAX_LENGTH = 10922;
 
 /**
@@ -954,7 +952,7 @@ function elasticpress_mapping( array $mapping, ?string $index = null ) : array {
 			}
 
 			if ( $inline_index_settings ) {
-				$package_contents = get_package_contents( $package_slug, $is_network_package );
+				$package_contents = Packages\get_package_contents( $package_slug, $is_network_package );
 				if ( ! $package_contents ) {
 					trigger_error( sprintf( 'Could not fetch %s package contents of "%s".', $type, $package_id ) );
 					continue;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -1193,6 +1193,7 @@ function elasticpress_mapping( array $mapping, ?string $index = null ) : array {
 function should_inline_settings() : bool {
 	$es_version = Elasticsearch::factory()->get_elasticsearch_version();
 
+	// Elasticsearch 7.4 is where the inline user_dictionary_rules config option was introduced.
 	return version_compare( $es_version, '7.4', '>=' )
 		? (bool) get_search_config_option( 'inline-index-settings', true )
 		: false;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -934,9 +934,7 @@ function elasticpress_mapping( array $mapping, ?string $index = null ) : array {
 	$synonyms = [];
 	$stopwords = [];
 	$kuromoji_dictionary = null;
-	$inline_index_settings = version_compare( $es_version, '7.4', '>=' )
-		? get_search_config_option( 'inline-index-settings', true )
-		: false;
+	$inline_index_settings = should_inline_settings();
 
 	foreach ( [ 'synonyms', 'stopwords', 'user-dictionary' ] as $type ) {
 		foreach ( [ 'uploaded', 'manual' ] as $sub_type ) {
@@ -1187,6 +1185,19 @@ function elasticpress_mapping( array $mapping, ?string $index = null ) : array {
 	}
 
 	return $mapping;
+}
+
+/**
+ * Returns where inline settings should be used.
+ *
+ * @return bool
+ */
+function should_inline_settings() : bool {
+	$es_version = Elasticsearch::factory()->get_elasticsearch_version();
+
+	return version_compare( $es_version, '7.4', '>=' )
+		? (bool) get_search_config_option( 'inline-index-settings', true )
+		: false;
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -983,7 +983,7 @@ function elasticpress_mapping( array $mapping, ?string $index = null ) : array {
 						$stopwords[ "{$sub_type}_{$type}_filter" ] = [
 							'type' => 'stop',
 							'ignore_case' => true,
-							'stopwords' => implode( ',', $package_contents ),
+							'stopwords' => $package_contents,
 						];
 					} else {
 						$stopwords[ "{$sub_type}_{$type}_filter" ] = [

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -250,6 +250,28 @@ function get_package_id( string $slug, bool $for_network = false ) : ?string {
 }
 
 /**
+ * Returns the contents of a package using its slug and network-wide flag.
+ *
+ * @param string $slug The package slug to get the package ID for.
+ * @param bool $for_network If true get the network level package ID.
+ *
+ * @return string|null
+ */
+function get_package_contents( string $slug, bool $for_network = false ) : ?string {
+	$path = get_package_path( $slug, $for_network );
+	if ( empty( $path ) ) {
+		return null;
+	}
+
+	if ( ! file_exists( $path ) ) {
+		trigger_error( sprintf( 'Package file "%s" does not exist at "%s".', $slug, $path ) );
+		return null;
+	}
+
+	return file_get_contents( $path ) ?: null;
+}
+
+/**
  * Process the packages form.
  *
  * @return void

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -13,6 +13,9 @@ use ElasticPress\Indexables;
 use ElasticPress\Utils;
 use WP_Error;
 
+// Maximum package file size recommended for inline settings.
+const MAX_INLINE_SETTINGS_SIZE_RECOMMENDED = 100 * 1024;
+
 /**
  * Bind hooks for ElasticSearch Packages.
  *

--- a/inc/packages/templates/config.php
+++ b/inc/packages/templates/config.php
@@ -88,6 +88,26 @@
 					<p>
 						<input type="file" accept="text/plain" id="user-dictionary-file" name="user-dictionary-file" />
 					</p>
+					<h3>
+					<label for="user-dictionary-text"><?php esc_html_e( 'Manual entry', 'altis' ); ?></label>
+						<?php if ( $types['user_dictionary']['manual_status'] ) : ?>
+							<span class="es-package-status es-package-status--<?php echo esc_attr( strtolower( $types['user_dictionary']['manual_status'] ) ); ?>">
+								<?php
+									// translators: %s replaced by status name e.g. 'ACTIVE', 'ERROR'.
+									echo esc_html( sprintf( __( 'Status: %s', 'altis' ), $types['user_dictionary']['manual_status'] ) );
+								?>
+							</span>
+						<?php endif; ?>
+					</h3>
+					<?php if ( $types['user_dictionary']['manual_error'] ) : ?>
+						<div class="notice notice-error">
+							<p><?php echo esc_html( $types['user_dictionary']['manual_error'] ); ?></p>
+						</div>
+					<?php endif; ?>
+					<textarea id="user-dictionary-text" name="user-dictionary-text" rows="10" cols="100%"><?php echo esc_textarea( $types['user_dictionary']['text'] ); ?></textarea>
+					<div class="notice-info">
+						<p><strong><?php echo esc_html__( 'Note that manual entry overrides uploaded dictionary file.', 'altis' ); ?></strong></p>
+					</div>
 					<p>
 						<input type="submit" class="button button-primary" value="<?php esc_attr_e( 'Update user dictionary', 'altis' ); ?>" />
 					</p>

--- a/inc/packages/templates/config.php
+++ b/inc/packages/templates/config.php
@@ -5,6 +5,10 @@
  * @package altis/search
  */
 
+use const Altis\Enhanced_Search\Packages\MAX_INLINE_SETTINGS_SIZE_RECOMMENDED;
+
+use function Altis\Enhanced_Search\should_inline_settings;
+
 ?>
 <div class="wrap">
 	<h1><?php esc_html_e( 'Search Configuration', 'altis' ); ?></h1>
@@ -82,6 +86,20 @@
 								gmdate( get_option( 'date_format', 'Y-m-d H:i:s' ), $types['user_dictionary']['file_date'] )
 							) );
 							?>
+							<?php if ( should_inline_settings() && filesize( $types['user_dictionary']['uploaded_file'] ) > MAX_INLINE_SETTINGS_SIZE_RECOMMENDED ) : ?>
+								<p>
+									<strong>
+										<?php
+											echo esc_html( sprintf(
+												// translators: %s is replaced by the file upload date.
+												__( 'Current file size (%.2fKB) exceeds recommended file size for inline settings (%.2fKB), consider disabling inline settings for optimal performance.', 'altis' ),
+												filesize( $types['user_dictionary']['uploaded_file'] ) / 1024,
+												MAX_INLINE_SETTINGS_SIZE_RECOMMENDED / 1024
+											) );
+										?>
+									</strong>
+								</p>
+							<?php endif; ?>
 						</p>
 						<input type="submit" class="components-button is-link is-destructive" name="user-dictionary-remove" value="<?php esc_attr_e( 'Remove user dictionary file', 'altis' ); ?>" />
 					<?php endif; ?>
@@ -164,6 +182,20 @@ sea biscuit, sea biscit => seabiscuit</pre>
 						) );
 						?>
 					</p>
+					<?php if ( should_inline_settings() && filesize( $types['synonyms']['uploaded_file'] ) > MAX_INLINE_SETTINGS_SIZE_RECOMMENDED ) : ?>
+						<p>
+							<strong>
+								<?php
+									echo esc_html( sprintf(
+										// translators: %s is replaced by the file upload date.
+										__( 'Current file size (%.2fKB) exceeds recommended file size for inline settings (%.2fKB), consider disabling inline settings for optimal performance.', 'altis' ),
+										filesize( $types['synonyms']['uploaded_file'] ) / 1024,
+										MAX_INLINE_SETTINGS_SIZE_RECOMMENDED / 1024
+									) );
+								?>
+							</strong>
+						</p>
+					<?php endif; ?>
 					<input type="submit" class="components-button is-link is-destructive" name="synonyms-remove" value="<?php esc_attr_e( 'Remove synonyms file', 'altis' ); ?>" />
 				<?php endif; ?>
 				<p>
@@ -229,6 +261,20 @@ please</pre>
 						) );
 						?>
 					</p>
+					<?php if ( should_inline_settings() && filesize( $types['stopwords']['uploaded_file'] ) > MAX_INLINE_SETTINGS_SIZE_RECOMMENDED ) : ?>
+						<p>
+							<strong>
+								<?php
+									echo esc_html( sprintf(
+										// translators: %s is replaced by the file upload date.
+										__( 'Current file size (%.2fKB) exceeds recommended file size for inline settings (%.2fKB), consider disabling inline settings for optimal performance.', 'altis' ),
+										filesize( $types['stopwords']['uploaded_file'] ) / 1024,
+										MAX_INLINE_SETTINGS_SIZE_RECOMMENDED / 1024
+									) );
+								?>
+							</strong>
+						</p>
+					<?php endif; ?>
 					<input type="submit" class="components-button is-link is-destructive" name="stopwords-remove" value="<?php esc_attr_e( 'Remove stop words file', 'altis' ); ?>" />
 				<?php endif; ?>
 				<p>

--- a/inc/packages/templates/config.php
+++ b/inc/packages/templates/config.php
@@ -5,10 +5,6 @@
  * @package altis/search
  */
 
-use const Altis\Enhanced_Search\Packages\MAX_INLINE_SETTINGS_SIZE_RECOMMENDED;
-
-use function Altis\Enhanced_Search\should_inline_settings;
-
 ?>
 <div class="wrap">
 	<h1><?php esc_html_e( 'Search Configuration', 'altis' ); ?></h1>
@@ -86,7 +82,7 @@ use function Altis\Enhanced_Search\should_inline_settings;
 								gmdate( get_option( 'date_format', 'Y-m-d H:i:s' ), $types['user_dictionary']['file_date'] )
 							) );
 							?>
-							<?php if ( should_inline_settings() && filesize( $types['user_dictionary']['uploaded_file'] ) > MAX_INLINE_SETTINGS_SIZE_RECOMMENDED ) : ?>
+							<?php if ( Altis\Enhanced_Search\should_inline_settings() && filesize( $types['user_dictionary']['uploaded_file'] ) > Altis\Enhanced_Search\Packages\MAX_INLINE_SETTINGS_SIZE_RECOMMENDED ) : ?>
 								<p>
 									<strong>
 										<?php
@@ -94,7 +90,7 @@ use function Altis\Enhanced_Search\should_inline_settings;
 												// translators: %s is replaced by the file upload date.
 												__( 'Current file size (%.2fKB) exceeds recommended file size for inline settings (%.2fKB), consider disabling inline settings for optimal performance.', 'altis' ),
 												filesize( $types['user_dictionary']['uploaded_file'] ) / 1024,
-												MAX_INLINE_SETTINGS_SIZE_RECOMMENDED / 1024
+												Altis\Enhanced_Search\Packages\MAX_INLINE_SETTINGS_SIZE_RECOMMENDED / 1024
 											) );
 										?>
 									</strong>
@@ -182,7 +178,7 @@ sea biscuit, sea biscit => seabiscuit</pre>
 						) );
 						?>
 					</p>
-					<?php if ( should_inline_settings() && filesize( $types['synonyms']['uploaded_file'] ) > MAX_INLINE_SETTINGS_SIZE_RECOMMENDED ) : ?>
+					<?php if ( Altis\Enhanced_Search\should_inline_settings() && filesize( $types['synonyms']['uploaded_file'] ) > Altis\Enhanced_Search\Packages\MAX_INLINE_SETTINGS_SIZE_RECOMMENDED ) : ?>
 						<p>
 							<strong>
 								<?php
@@ -190,7 +186,7 @@ sea biscuit, sea biscit => seabiscuit</pre>
 										// translators: %s is replaced by the file upload date.
 										__( 'Current file size (%.2fKB) exceeds recommended file size for inline settings (%.2fKB), consider disabling inline settings for optimal performance.', 'altis' ),
 										filesize( $types['synonyms']['uploaded_file'] ) / 1024,
-										MAX_INLINE_SETTINGS_SIZE_RECOMMENDED / 1024
+										Altis\Enhanced_Search\Packages\MAX_INLINE_SETTINGS_SIZE_RECOMMENDED / 1024
 									) );
 								?>
 							</strong>
@@ -261,7 +257,7 @@ please</pre>
 						) );
 						?>
 					</p>
-					<?php if ( should_inline_settings() && filesize( $types['stopwords']['uploaded_file'] ) > MAX_INLINE_SETTINGS_SIZE_RECOMMENDED ) : ?>
+					<?php if ( Altis\Enhanced_Search\should_inline_settings() && filesize( $types['stopwords']['uploaded_file'] ) > Altis\Enhanced_Search\Packages\MAX_INLINE_SETTINGS_SIZE_RECOMMENDED ) : ?>
 						<p>
 							<strong>
 								<?php
@@ -269,7 +265,7 @@ please</pre>
 										// translators: %s is replaced by the file upload date.
 										__( 'Current file size (%.2fKB) exceeds recommended file size for inline settings (%.2fKB), consider disabling inline settings for optimal performance.', 'altis' ),
 										filesize( $types['stopwords']['uploaded_file'] ) / 1024,
-										MAX_INLINE_SETTINGS_SIZE_RECOMMENDED / 1024
+										Altis\Enhanced_Search\Packages\MAX_INLINE_SETTINGS_SIZE_RECOMMENDED / 1024
 									) );
 								?>
 							</strong>

--- a/load.php
+++ b/load.php
@@ -24,6 +24,7 @@ add_action( 'altis.modules.init', function () {
 		'fuzziness' => 'auto:4,7',
 		'users' => true,
 		'terms' => true,
+		'inline-index-settings' => true,
 	];
 	Altis\register_module( 'search', __DIR__, 'Search', $default_settings, __NAMESPACE__ . '\\bootstrap' );
 } );


### PR DESCRIPTION
- Defaults to inline index settings, configurable through Altis config.
- Adds textarea input for Japanese user dictionary, and aligns the code for the three package types.
- Updates docs to reference the updates and config option.