### PR TITLE
Add note about protected meta and how to index it

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,8 @@ Content that is indexed in the search index by default:
 - Terms
 - Term Meta
 
+**Note:** Post meta that is "protected"--i.e. has a key beginning with `_`--will not be indexed automatically. To index these fields, use the `ep_prepare_meta_allowed_protected_keys` filter. It will accept a value of boolean `true` (which will index *all* protected meta) or an array containing the keys of specific protected meta fields you want to index.
+
 When used in conjunction with the [Media Rekognition](docs://media/image-recognition.md) feature, all images are processed for automatic keyword detection and stored in the search index too.
 
 ## CMS Query Integration

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,7 @@ Content that is indexed in the search index by default:
 - Terms
 - Term Meta
 
-**Note:** Post meta that is "protected"--i.e. has a key beginning with `_`--will not be indexed automatically. To index these fields, use the `ep_prepare_meta_allowed_protected_keys` filter. It will accept a value of boolean `true` (which will index *all* protected meta) or an array containing the keys of specific protected meta fields you want to index.
+**Note:** Post meta that is "protected" - i.e. has a key beginning with `_` - will not be indexed automatically. To index these fields, use the `ep_prepare_meta_allowed_protected_keys` filter. It will accept a value of boolean `true` (which will index *all* protected meta) or an array containing the keys of specific protected meta fields you want to index.
 
 When used in conjunction with the [Media Rekognition](docs://media/image-recognition.md) feature, all images are processed for automatic keyword detection and stored in the search index too.
 


### PR DESCRIPTION
Protected meta fields are not indexed by default, but the documentation doesn't mention this (and in fact sort of implies that they _are_ indexed). This adds a note clarifying, and providing instructions on how to index said class of fields.