### PR TITLE
Add filter to autosuggest endpoint to modify query

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -133,3 +133,16 @@ Depending on the configuration specified for `facets`, if the `match-type` prope
 
 ### Search Form Auto Suggest
 This feature enhances search forms on the website to show a dropdown list of suggestions as users type.
+
+Because the query is sent from the client side the `post_filter` part of the query is hardcoded to only allow publicly searchable posts with the status `publish` to be returned.
+
+The query can be modified using the `altis.search.autosuggest_query` filter, for example:
+
+```php
+add_filter( 'altis.search.autosuggest_query', function ( array $query ) : array {
+	$query['post_filter']['bool']['must_not'] = [
+		[ 'term' => [ 'post.meta._hide.raw' => '1' ] ]
+	];
+	return $query;
+} );
+```

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -1978,8 +1978,8 @@ function handle_autosuggest_endpoint() {
 	$search = $features->get_registered_feature( 'search' );
 
 	// Force post filter value.
-	// This is necessary because the ES query is passed frmo the client side,
-	// and we want to ensure only published, searchable content.
+	// This is necessary because the ES query is passed from the client side,
+	// and we want to ensure only published, searchable content is returned.
 	$json['post_filter'] = [
 		'bool' => [
 			'must' => [
@@ -1997,7 +1997,6 @@ function handle_autosuggest_endpoint() {
 		],
 	];
 
-	
 	/**
 	 * Filter the autosuggest query JSON.
 	 *

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -1978,6 +1978,8 @@ function handle_autosuggest_endpoint() {
 	$search = $features->get_registered_feature( 'search' );
 
 	// Force post filter value.
+	// This is necessary because the ES query is passed frmo the client side,
+	// and we want to ensure only published, searchable content.
 	$json['post_filter'] = [
 		'bool' => [
 			'must' => [
@@ -1994,6 +1996,16 @@ function handle_autosuggest_endpoint() {
 			],
 		],
 	];
+
+	
+	/**
+	 * Filter the autosuggest query JSON.
+	 *
+	 * This is the data that is json encoded and passed as the elasticsearch request body.
+	 *
+	 * @param array $json ES Query.
+	 */
+	$json = apply_filters( 'altis.search.autosuggest_json', $json );
 
 	/**
 	 * Elasticsearch client object.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -1958,8 +1958,8 @@ function handle_autosuggest_endpoint() {
 	}
 
 	// Validate data.
-	$json = json_decode( WP_REST_Server::get_raw_data(), true );
-	if ( ! $json ) {
+	$query = json_decode( WP_REST_Server::get_raw_data(), true );
+	if ( ! $query ) {
 		wp_send_json( [], 200 );
 	}
 
@@ -1980,7 +1980,7 @@ function handle_autosuggest_endpoint() {
 	// Force post filter value.
 	// This is necessary because the ES query is passed from the client side,
 	// and we want to ensure only published, searchable content is returned.
-	$json['post_filter'] = [
+	$query['post_filter'] = [
 		'bool' => [
 			'must' => [
 				[
@@ -1998,13 +1998,13 @@ function handle_autosuggest_endpoint() {
 	];
 
 	/**
-	 * Filter the autosuggest query JSON.
+	 * Filter the autosuggest query.
 	 *
-	 * This is the data that is json encoded and passed as the elasticsearch request body.
+	 * This is the data that is json encoded and passed as the Elasticsearch request body.
 	 *
-	 * @param array $json ES Query.
+	 * @param array $query ES Query.
 	 */
-	$json = apply_filters( 'altis.search.autosuggest_json', $json );
+	$query = apply_filters( 'altis.search.autosuggest_query', $query );
 
 	/**
 	 * Elasticsearch client object.
@@ -2015,7 +2015,7 @@ function handle_autosuggest_endpoint() {
 
 	// Pass to EP.
 	$response = $client->remote_request( Indexables::factory()->get( 'post' )->get_index_name() . '/_search', [
-		'body'   => json_encode( $json ),
+		'body'   => json_encode( $query ),
 		'method' => 'POST',
 	] );
 


### PR DESCRIPTION
My use case is that I want to restrict what is shown in the autosuggest endpoint, to hide content with a certain meta key. 

A filter on the query would be useful to do this. It is a bit of a tricky one as the format is an ES query, not a WP query. 

Fixes #308 