### PR TITLE
Sanitize WP query array args

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -140,6 +140,9 @@ function load_elasticpress() {
 	// Limit search query length.
 	add_action( 'pre_get_posts', __NAMESPACE__ . '\\limit_search_query_length', 1000 );
 
+	// Sanitize query arguments.
+	add_action( 'pre_get_posts', __NAMESPACE__ . '\\sanitize_query_args', 1000 );
+
 	// Ensure upgrades aren't attempted during install due to db access.
 	if ( defined( 'WP_INITIAL_INSTALL' ) && WP_INITIAL_INSTALL ) {
 		add_filter( 'pre_site_option_ep_version', '__return_false' );
@@ -2055,4 +2058,37 @@ function limit_search_query_length( WP_Query $query ) : void {
 	$search = trim( $search );
 
 	$query->set( 's', $search );
+}
+
+/**
+ * Sanitizes array type query args to ensure there are no empty values.
+ *
+ * Empty values in `terms` queries will cause an ES query to error.
+ *
+ * @param \WP_Query $query The WP_Query instance (passed by reference).
+ */
+function sanitize_query_args( WP_Query $query ) : void {
+	$keys_to_sanitize = [
+		'author__in',
+		'author__not_in',
+		'category__and',
+		'category__in',
+		'category__not_in',
+		'tag__and',
+		'tag__in',
+		'tag__not_in',
+		'tag_slug__and',
+		'tag_slug__in',
+		'post_parent__in',
+		'post_parent__not_in',
+		'post__in',
+		'post__not_in',
+		'post_name__in',
+	];
+	foreach ( $keys_to_sanitize as $key ) {
+		if ( empty( $query->get( $key ) ) ) {
+			continue;
+		}
+		$query->set( $key, array_values( array_filter( (array) $query->get( $key ) ) ) );
+	}
 }


### PR DESCRIPTION
ES can break if a `terms` query contains a non empty array that has empty values. This can happen in some cases where Yoast SEO indexing has not completed for instance.