### PR TITLE
Fix array key

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -426,7 +426,7 @@ function fix_mime_type_query( array $query, array $args ) : array {
 		}
 		// Extract base regex mime type if present.
 		if ( ! empty( $sub_query['regexp']['post_mime_type'] ) ) {
-			$mime_types = [ $sub_query['terms']['post_mime_type'] ];
+			$mime_types = [ $sub_query['regexp']['post_mime_type'] ];
 		}
 
 		if ( empty( $mime_types ) ) {


### PR DESCRIPTION
This PR fixes an assumed copy-paste mistake. The code checks for existence of one array element/path, but then accesses another one (the same as the code block before it).

With configurations/queries where `terms` is not set, but `regexp` is, this will trigger two PHP notices.