### PR TITLE
Bug fixes for ES user dictionaries

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -1116,6 +1116,11 @@ function elasticpress_mapping( array $mapping, ?string $index = null ) : array {
 		}
 	}
 
+	// Short circuit early if we're only dealing with settings.
+	if ( ! isset( $mapping['mappings'] ) ) {
+		return $mapping;
+	}
+
 	if ( version_compare( $es_version, '7', '<' ) ) {
 		$new_mapping = $mapping['mappings'][ $mapping_type ];
 	} else {

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -327,7 +327,7 @@ function handle_form() : void {
 			$has_changed = true;
 
 			// Check for updates.
-			// phpcs:ignore -- Allow error supporession for existing ID check when file exists.
+			// phpcs:ignore -- Allow error suppression for existing ID check when file exists.
 			if ( file_exists( $file ) && ! empty( @get_package_id( "manual-{$type}", $for_network ) ) ) {
 				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 				$has_changed = $text !== file_get_contents( $file );
@@ -582,6 +582,8 @@ function get_site_indices( ?int $blog_id = null ) : string {
  */
 function do_settings_update( bool $for_network = false, bool $update_data = false ) : void {
 	// Get latest settings.
+	// We use 'x-post-1' one here to mimic an index name so that our generic customised settings
+	// can be returned without needing to replicate the code in EP's put_mapping methods.
 	$mapping = Enhanced_Search\elasticpress_mapping( [], 'x-post-1' );
 	$settings = $mapping['settings'];
 

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -187,7 +187,8 @@ function add_error_message( WP_Error $error, bool $for_network = false ) : void 
  * @return string
  */
 function get_packages_dir() : string {
-	$path = WP_CONTENT_DIR . '/uploads/es-packages';
+	$upload_dir = wp_get_upload_dir();
+	$path = $upload_dir['basedir'] . '/es-packages';
 
 	/**
 	 * Filter the path at which Elasticsearch package files are stored.
@@ -326,7 +327,8 @@ function handle_form() : void {
 			$has_changed = true;
 
 			// Check for updates.
-			if ( file_exists( $file ) ) {
+			// phpcs:ignore -- Allow error supporession for existing ID check when file exists.
+			if ( file_exists( $file ) && ! empty( @get_package_id( "manual-{$type}", $for_network ) ) ) {
 				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 				$has_changed = $text !== file_get_contents( $file );
 			}
@@ -580,7 +582,7 @@ function get_site_indices( ?int $blog_id = null ) : string {
  */
 function do_settings_update( bool $for_network = false, bool $update_data = false ) : void {
 	// Get latest settings.
-	$mapping = Enhanced_Search\elasticpress_mapping( [] );
+	$mapping = Enhanced_Search\elasticpress_mapping( [], 'x-post-1' );
 	$settings = $mapping['settings'];
 
 	if ( $for_network ) {
@@ -629,6 +631,7 @@ function update_index_settings( string $index, array $settings, bool $update_dat
 	$client->remote_request( $index . '/_settings', [
 		'method' => 'PUT',
 		'body' => wp_json_encode( $settings ),
+		'timeout' => 15,
 	], [], 'put_settings' );
 
 	// Open the index.


### PR DESCRIPTION
Automatic updates to the index settings when settings synonyms etc was failing during testing, partly caused by the introduction of checking the indexable type in the mapping config filter.