### PR TITLE
Update broken term search test

### DIFF
--- a/tests/acceptance/ElasticSearchCest.php
+++ b/tests/acceptance/ElasticSearchCest.php
@@ -58,14 +58,14 @@ class ElasticSearchCest {
 		$I->see( 'Alpha', '.column-primary' );
 
 		$I->submitForm( '#wpbody .search-form', [
-			's' => 'theda',
+			's' => 'the',
 		] );
 		$I->see( 'Theta', '.column-primary' );
 
 		$I->submitForm( '#wpbody .search-form', [
-			's' => 'Omaga',
+			's' => 'thet',
 		] );
-		$I->see( 'Omega', '.column-primary' );
+		$I->see( 'Theta', '.column-primary' );
 	}
 
 	/**


### PR DESCRIPTION
Term search does not have fuzziness by default. Only supported if used advanced search mode.