### PR TITLE
Unnecessary HTTP API request on pages that enqueue autosuggest

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -1950,7 +1950,7 @@ function custom_search_results_post_type_args( array $args, string $post_type ) 
 function split_large_ep_request( $request, array $query, array $args, int $failures ) {
 
 	if ( empty( $args['body'] ) || $args['method'] !== 'POST' || ! strpos( $query['url'], '/_bulk' ) ) {
-		return wp_remote_request( $query['url'], $args );
+		return $request;
 	}
 
 	// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -202,7 +202,7 @@ function load_elasticpress() {
 	add_action( 'init', __NAMESPACE__ . '\\configure_documents_feature', 1 );
 
 	// Use ElasticPress request intercepting to chunk large requests.
-	add_filter( 'ep_intercept_remote_request', '__return_true' );
+	add_filter( 'ep_intercept_remote_request', '__return_true', 11 );
 	add_filter( 'ep_do_intercept_request', __NAMESPACE__ . '\\split_large_ep_request', 10, 4 );
 
 	// Handle autosuggest requests.
@@ -1950,12 +1950,11 @@ function custom_search_results_post_type_args( array $args, string $post_type ) 
 function split_large_ep_request( $request, array $query, array $args, int $failures ) {
 
 	if ( empty( $args['body'] ) || $args['method'] !== 'POST' || ! strpos( $query['url'], '/_bulk' ) ) {
-		return $request;
+		return is_wp_error( $request ) ? wp_remote_request( $query['url'], $args ) : $request;
 	}
 
 	// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 	$body_size_limit = apply_filters( 'altis.search.request-size-limit', 1024 * 1024 * 9 ); // 9 MB
-	$combined_response = null;
 	$body = $args['body'];
 	$args['body'] = '';
 	$requests = [];


### PR DESCRIPTION
On a site that uses autosuggest, a server-side HTTP API request to ES is triggered when the autosuggest JavaScript is enqueued. It appears this request is unnecessary.

Steps to reproduce:

1. Enable autosuggest in composer.json
   ```json
   "search": {
   	"autosuggest": true
   },
   ```
2. View a page containing a search form
3. Open the HTTP API panel in Query Monitor and observe that a request to ES is performed
4. Reload the page a few times and confirm the request from Altis Enhance Search occurs on every page load

This request comes from the `split_large_ep_request()` function that's hooked into the `ep_do_intercept_request` filter. This filter runs when `\ElasticPress\Feature\Autosuggest\generate_search_query()` is called within `\ElasticPress\Feature\Autosuggest\enqueue_scripts()` to enqueue the EP autosuggest JS.

EP Autosuggest adds its own `intercept_search_request()` callback to the `ep_do_intercept_request` filter which performs an HTTP API request but is wrapped in a caching layer.

**_This needs thorough testing_** as I don't know what other impact this change could have.