### PR TITLE
Change priority on ep_do_intercept_request

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -202,7 +202,7 @@ function load_elasticpress() {
 	add_action( 'init', __NAMESPACE__ . '\\configure_documents_feature', 1 );
 
 	// Use ElasticPress request intercepting to chunk large requests.
-	// Priority 11 to force these after ElasticPress\Feature\Autosuggest's dummy interceptions
+	// Priority 11 to force these after ElasticPress\Feature\Autosuggest's dummy interceptions.
 	add_filter( 'ep_intercept_remote_request', '__return_true', 11 );
 	add_filter( 'ep_do_intercept_request', __NAMESPACE__ . '\\split_large_ep_request', 11, 4 );
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -203,7 +203,7 @@ function load_elasticpress() {
 
 	// Use ElasticPress request intercepting to chunk large requests.
 	add_filter( 'ep_intercept_remote_request', '__return_true', 11 );
-	add_filter( 'ep_do_intercept_request', __NAMESPACE__ . '\\split_large_ep_request', 10, 4 );
+	add_filter( 'ep_do_intercept_request', __NAMESPACE__ . '\\split_large_ep_request', 11, 4 );
 
 	// Handle autosuggest requests.
 	add_action( 'template_redirect', __NAMESPACE__ . '\\handle_autosuggest_endpoint' );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -202,6 +202,7 @@ function load_elasticpress() {
 	add_action( 'init', __NAMESPACE__ . '\\configure_documents_feature', 1 );
 
 	// Use ElasticPress request intercepting to chunk large requests.
+	// Priority 11 to force these after ElasticPress\Feature\Autosuggest's dummy interceptions
 	add_filter( 'ep_intercept_remote_request', '__return_true', 11 );
 	add_filter( 'ep_do_intercept_request', __NAMESPACE__ . '\\split_large_ep_request', 11, 4 );
 


### PR DESCRIPTION
In #405 we attempted to get rid of an HTTP request caused by a dummy call to `WP_Query` by EP's Autosuggest feature. However, the request continued to show up as our call on `ep_do_intercept_request` runs before the [intercept callback](https://github.com/humanmade/altis-enhanced-search/blob/bbd46c07c043406006978f2c6cd07c6bf11c7a3d/lib/elasticpress/includes/classes/Feature/Autosuggest/Autosuggest.php#L607) in Autosuggest, which converts the initial `WP_Error` to an HTTP response, either by running `wp_remote_request` or obtaining the results from cache.

This commit sets our `ep_do_intercept_request` to run at a later priority, meaning that if Autosuggest's intercept is set to run,
we will no longer get the default `WP_Error` object, rendering the rest of the logic behind #405 accurate.

Fixes #414