### PR TITLE
Correct sprintf translation arguement.

### DIFF
--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -369,7 +369,7 @@ function handle_form() : void {
 				$errors[] = new WP_Error(
 					'file_type_incorrect',
 					// translators: %s replaced by search package file path.
-					sprintf( __( 'Detected unsupported file type %, only text files are supported.', 'altis' ), $mime_type )
+					sprintf( __( 'Detected unsupported file type %s, only text files are supported.', 'altis' ), $mime_type )
 				);
 
 			} else {


### PR DESCRIPTION
Related issue #422 

#### Error

> Fatal error: Uncaught Error: Unknown format specifier ","
> in /usr/src/app/packages/enhanced-search/inc/packages/namespace.php on line 372

#### Issue
> sprintf( __( 'Detected unsupported file type %, only text files are supported.', 'altis' ), $mime_type )

#### Solution
Adding "s" for the `sprintf` so it's "%s" resolved this issue.
> sprintf( __( 'Detected unsupported file type %s, only text files are supported.', 'altis' ), $mime_type )
