### PR TITLE
Fix ElasticPress constraints to working versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": ">=7.1",
-		"10up/elasticpress": "~4.5.2",
+		"10up/elasticpress": "4.5.0 || ~4.5.3",
 		"humanmade/debug-bar-elasticpress": "~1.6.3"
 	},
 	"autoload" : {


### PR DESCRIPTION
Fixes EP constraints to versions (and possible future bugfixed patch versions) that do not have the fatal error:

```
Index failed: Uncaught Error: Call to undefined method ElasticPress\ IndexHelper::process_error_ limit() in /usr/src/app/vendor/10up/elasticpress/includes/classes/IndexHelper.php:693
```