### PR TITLE
Reformat docs files after linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Import Travis configuration from dev-tools repo
 version: ~> 1.0
 import:
-  - source: humanmade/altis-dev-tools:travis/module.yml@0bfa112
+  - source: humanmade/altis-dev-tools:travis/module.yml@0bfa112a
     mode: deep_merge_append

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Import Travis configuration from dev-tools repo
 version: ~> 1.0
 import:
-  - source: humanmade/altis-dev-tools:travis/module.yml@f1fd9a5
+  - source: humanmade/altis-dev-tools:travis/module.yml@0bfa112
     mode: deep_merge_append

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,9 @@
 # Search
 
-![](./assets/banner-search.png)
+![Search Banner](./assets/banner-search.png)
 
-The Search module provides a mirrored Elasticsearch index of all CMS content that is optimized for search relevance, speed and accuracy. This operates at a higher level than the primary datastore (MySQL) and is the recommended solution for searching.
+The Search module provides a mirrored Elasticsearch index of all CMS content that is optimized for search relevance, speed and
+accuracy. This operates at a higher level than the primary data store (MySQL) and is the recommended solution for searching.
 
 The benefits of using Elasticsearch over MySQL search queries include:
 
@@ -10,76 +11,91 @@ The benefits of using Elasticsearch over MySQL search queries include:
 - Advanced text analysis
   - Removing HTML
   - Language dependent word stemming and stopwords
-  - Language dependent tokenisation
+  - Language dependent tokenization
 - Configurable relevancy scores
 - Fuzzy matching
 - Synonyms
 - Aggregations for faceted search and statistics
 
-The default Search index and related functionality is provided by the [ElasticPress plugin](https://github.com/10up/ElasticPress) and the multilingual support is derived from [the WordPress.com Elasticsearch library](https://github.com/Automattic/wpes-lib).
-
+The default Search index and related functionality is provided by the [ElasticPress plugin](https://github.com/10up/ElasticPress)
+and the multilingual support is derived from [the WordPress.com Elasticsearch library](https://github.com/Automattic/wpes-lib).
 
 ## Support
 
-Altis provides the Search module and underlying Elasticsearch server to facilitate search on your site, with default configuration to meet a majority of use cases.
+Altis provides the Search module and underlying Elasticsearch server to facilitate search on your site, with default configuration
+to meet a majority of use cases.
 
-Using developer features of the Search module **requires understanding how Elasticsearch works**. We recommend reading the [Elasticsearch guide by Elastic](https://www.elastic.co/guide/en/elasticsearch/).
+Using developer features of the Search module **requires understanding how Elasticsearch works**. We recommend reading
+the [Elasticsearch guide by Elastic](https://www.elastic.co/guide/en/elasticsearch/).
 
-Modifying and tuning search queries for relevance is a subjective process. Additionally, much like writing complex database queries, building custom Elasticsearch queries requires a deep understanding of how Elasticsearch works.
+Modifying and tuning search queries for relevance is a subjective process. Additionally, much like writing complex database queries,
+building custom Elasticsearch queries requires a deep understanding of how Elasticsearch works.
 
-Guides contained in this documentation are on a best-effort basis; for help with tuning or customising search results, the Altis team can help you find a partner to facilitate your use. Altis support cannot help with tuning results, tweaking configuration, or writing custom Elasticsearch queries.
-
+Guides contained in this documentation are on a best-effort basis; for help with tuning or customising search results, the Altis
+team can help you find a partner to facilitate your use. Altis support cannot help with tuning results, tweaking configuration, or
+writing custom Elasticsearch queries.
 
 ## Terminology
 
-Altis includes the Search module (`altis/enhanced-search`) which is built upon a WordPress plugin called ElasticPress, made by our friends at [10up](https://10up.com). Altis adds additional functionality, including deep integration into the Altis platform.
+Altis includes the Search module (`altis/enhanced-search`) which is built upon a WordPress plugin called ElasticPress, made by our
+friends at [10up](https://10up.com). Altis adds additional functionality, including deep integration into the Altis platform.
 
-Altis Cloud includes Elasticsearch backend servers, which are a database tuned specifically for search. The Search module sets up a connection to the Elasticsearch servers.
+Altis Cloud includes Elasticsearch backend servers, which are a database tuned specifically for search. The Search module sets up a
+connection to the Elasticsearch servers.
 
-When content is created or updated, that content is **indexed** into Elasticsearch. This works similar to caching, where a copy of your original data is stored within Elasticsearch in an **index** (effectively, a database table). Unlike your original data, the index can also contain additional data just for search, including generated or rendered data. Each item of content is stored as a **document** which has **fields** containing the data.
+When content is created or updated, that content is **indexed** into Elasticsearch. This works similar to caching, where a copy of
+your original data is stored within Elasticsearch in an **index** (effectively, a database table). Unlike your original data, the
+index can also contain additional data just for search, including generated or rendered data. Each item of content is stored as a *
+*document** which has **fields** containing the data.
 
-When a user searches for content on your site, Altis converts this into a **query**. The query is run in Elasticsearch against your indexed content, which generates results with a **relevancy score**. Relevancy scores are based on the index configuration, field configuration, the query being run, and the indexed data.
-
+When a user searches for content on your site, Altis converts this into a **query**. The query is run in Elasticsearch against your
+indexed content, which generates results with a **relevancy score**. Relevancy scores are based on the index configuration, field
+configuration, the query being run, and the indexed data.
 
 ## Indexing
 
-The indexing process is performed automatically for you by Altis, indexing [most forms of content on your site](./indexing/README.md). Content can be [reindexed if necessary](./indexing/reindexing.md), and [additional data can be indexed](./indexing/additional-data.md).
-
+The indexing process is performed automatically for you by Altis,
+indexing [most forms of content on your site](./indexing/README.md). Content can
+be [reindexed if necessary](./indexing/reindexing.md), and [additional data can be indexed](./indexing/additional-data.md).
 
 ## Querying
 
-Altis [automatically integrates with search queries](./querying/cms-integration.md), as well as providing [autosuggest functionality automatically for your search forms](./querying/autosuggest.md).
+Altis [automatically integrates with search queries](./querying/cms-integration.md), as well as
+providing [autosuggest functionality automatically for your search forms](./querying/autosuggest.md).
 
 Developers can also use [custom queries](./querying/custom-queries.md) for advanced feature development.
 
-
 ## Configuration
 
-Altis provides [various configuration options](./configuration/README.md) to allow adjusting ElasticPress and Elasticsearch behaviour.
+Altis provides [various configuration options](./configuration/README.md) to allow adjusting ElasticPress and Elasticsearch
+behaviour.
 
-You can also use these options to [tune relevancy scoring](./configuration/tuning.md), including [date-based "decay"](./configuration/date-decay.md).
+You can also use these options to [tune relevancy scoring](./configuration/tuning.md),
+including [date-based "decay"](./configuration/date-decay.md).
 
-Users can also use the [custom user dictionary settings](./configuration/custom-dictionaries.md) to adjust how text is analyzed, including support for synonyms, stop words and custom text analysis for Japanese.
-
+Users can also use the [custom user dictionary settings](./configuration/custom-dictionaries.md) to adjust how text is analyzed,
+including support for synonyms, stop words and custom text analysis for Japanese.
 
 ## Disabling Search
 
-The Search module works by overriding default WordPress search, which uses MySQL full-text search. If you would prefer to use MySQL search, you can deactivate the search module via your config:
+The Search module works by overriding default WordPress search, which uses MySQL full-text search. If you would prefer to use MySQL
+search, you can deactivate the search module via your config:
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"modules": {
-				"search": {
-					"enabled": false
-				}
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "modules": {
+                "search": {
+                    "enabled": false
+                }
+            }
+        }
+    }
 }
 ```
 
-**Note:** turning this module off does not remove the Elasticsearch server. This can still be used for [Native Analytics](docs://analytics/native/README.md) and any custom use cases.
+**Note:** turning this module off does not remove the Elasticsearch server. This can still be used
+for [Native Analytics](docs://analytics/native/README.md) and any custom use cases.
 
 Additionally, this will increase load on your database servers. Depending on your Altis subscription, this may incur extra cost.

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -4,26 +4,27 @@ Altis strives to provide a great out-of-the-box search experience for most uses.
 
 For advanced usage, additional configuration is available to adjust search behaviour in indexing and querying.
 
-
 ## Tuning
 
-When searching, results can be ordered by relevancy score. This score is based on a blend of various factors, including index configuration, field configuration, the query being run, and the indexed data.
+When searching, results can be ordered by relevancy score. This score is based on a blend of various factors, including index
+configuration, field configuration, the query being run, and the indexed data.
 
-To help adjust relevancy, Altis provides [various configuration settings to tune relevancy and search behaviour](./tuning.md), allowing for stricter or more permissive matching, advanced query operators, and fuzzy matching.
-
+To help adjust relevancy, Altis provides [various configuration settings to tune relevancy and search behaviour](./tuning.md),
+allowing for stricter or more permissive matching, advanced query operators, and fuzzy matching.
 
 ## Date Decay
 
-For most use cases, you'll want to treat newer results as more relevant than older ones. Altis includes [date decay functionality](./date-decay.md) which automatically adjusts relevancy scores based on dates. These parameters can be tuned as part of the configuration.
-
-
+For most use cases, you'll want to treat newer results as more relevant than older ones. Altis
+includes [date decay functionality](./date-decay.md) which automatically adjusts relevancy scores based on dates. These parameters
+can be tuned as part of the configuration.
 
 ## User Dictionaries
 
-When indexing content, Elasticsearch uses analyzers to convert text from a raw string into data which can be queried. Altis provides [analyzers for common languages](../language-support.md) out of the box.
+When indexing content, Elasticsearch uses analyzers to convert text from a raw string into data which can be queried. Altis
+provides [analyzers for common languages](../language-support.md) out of the box.
 
-Altis also provides the ability to upload [custom user dictionaries](./custom-dictionaries.md), which allow adding synonyms, stop words and custom text analysis for Japanese to improve analysis.
-
+Altis also provides the ability to upload [custom user dictionaries](./custom-dictionaries.md), which allow adding synonyms, stop
+words and custom text analysis for Japanese to improve analysis.
 
 ## Additional Configuration Options
 
@@ -41,13 +42,17 @@ The following options can be enabled/disabled via the search configuration.
 
 To find related posts leveraging Elasticsearch, use the `ep_find_related()` function.
 
-The function requires a single parameter ( `$post_id` ) with another optional parameter ( `$return` ). The `$post_id` will be used to find the posts that are related to it, with `$return` specifying the number of related posts to return, which defaults to 5.
+The function requires a single parameter ( `$post_id` ) with another optional parameter ( `$return` ). The `$post_id` will be used
+to find the posts that are related to it, with `$return` specifying the number of related posts to return, which defaults to 5.
 
-If an out of the box solution is desired, the "ElasticPress - Related Posts" widget can be added to your site's sidebar. In order for the widget to work correctly it needs to be added to the sidebar which will be displayed for a single post.
-
+If an out of the box solution is desired, the "ElasticPress - Related Posts" widget can be added to your site's sidebar. In order
+for the widget to work correctly it needs to be added to the sidebar which will be displayed for a single post.
 
 ### Facets
 
-Facets are a feature in ElasticPress which add control to filter content by one or more taxonomies. A widget can be added so when viewing a content list (archive), the taxonomy and all of its terms will be displayed. This will allow a vistors to further filter content.
+Facets are a feature in ElasticPress which add control to filter content by one or more taxonomies. A widget can be added so when
+viewing a content list (archive), the taxonomy and all of its terms will be displayed. This will allow a visitor to further filter
+content.
 
-Depending on the configuration specified for `facets`, if the `match-type` property is set to `any`, it will force the results to match any selected taxonomy term. If set to `all`, it will match to results with all of the selected terms.
+Depending on the configuration specified for `facets`, if the `match-type` property is set to `any`, it will force the results to
+match any selected taxonomy term. If set to `all`, it will match to results with all of the selected terms.

--- a/docs/configuration/custom-dictionaries.md
+++ b/docs/configuration/custom-dictionaries.md
@@ -1,18 +1,28 @@
 # Custom User Dictionaries
 
-The search module supports 3 types of custom dictionaries for helping to tune search results for your content. These are synonyms, stop words and custom text analysis for Japanese.
+The search module supports 3 types of custom dictionaries for helping to tune search results for your content. These are synonyms,
+stop words and custom text analysis for Japanese.
 
-In the website admin, you can upload text files (`.txt` only) and/or manually enter them on the [Search Configuration](admin://admin.php?page=search-config) screen.
+In the website admin, you can upload text files (`.txt` only) and/or manually enter them on
+the [Search Configuration](admin://admin.php?page=search-config) screen.
 
-Altis includes support for a Japanese user dictionary to be used by the [kuromoji tokenizer](https://www.elastic.co/guide/en/elasticsearch/plugins/6.3/analysis-kuromoji-tokenizer.html) that splits words up during analysis. Synonyms and stop words are "filters" so multiple files (uploaded and manually entered) can be used for those.
+Altis includes support for a Japanese user dictionary to be used by
+the [Kuromoji tokenizer](https://www.elastic.co/guide/en/elasticsearch/plugins/6.3/analysis-kuromoji-tokenizer.html) that splits
+words up during analysis. Synonyms and stop words are "filters" so multiple files (uploaded and manually entered) can be used for
+those.
 
-User dictionaries can be configured for [the entire network](admin://network/admin.php?page=search-config) (provided the subsites match the primary site language) or at an individual site level.
+User dictionaries can be configured for [the entire network](admin://network/admin.php?page=search-config) (provided the sub-sites
+match the primary site language) or at an individual site level.
 
-Note that for the user dictionary, manual entries will override any uploaded files. So make sure to use one or the other, not both, unlike what you can do with synonyms and stop words.
+Note that for the user dictionary, manual entries will override any uploaded files. So make sure to use one or the other, not both,
+unlike what you can do with synonyms and stop words.
 
-By default, Altis uses inline index settings to include all of these dictionaries, however, it is recommended to turn this feature off in case uploaded files are bigger than 100KB. This helps to improve the performance and ES cluster sizes (see below). Altis will notify you if your file size exceeds the recommended limit within the configuration page.
+By default, Altis uses inline index settings to include all of these dictionaries, however, it is recommended to turn this feature
+off in case uploaded files are bigger than 100KB. This helps to improve the performance and ES cluster sizes (see below). Altis will
+notify you if your file size exceeds the recommended limit within the configuration page.
 
-**Note**: If you do not use inline index settings you will need to manually reindex your content after making changes to synonyms, stopwords or the Japanese user dictionary.
+**Note**: If you do not use inline index settings you will need to manually reindex your content after making changes to synonyms,
+stopwords or the Japanese user dictionary.
 
 ```json
 {
@@ -30,59 +40,68 @@ By default, Altis uses inline index settings to include all of these dictionarie
 
 ## Updating User Dictionaries
 
-After updating custom dictionaries you will need to [reindex your content](../reindexing-content.md) unless you are on Elasticsearch version 7.8 or higher.
+After updating custom dictionaries you will need to [reindex your content](../reindexing-content.md) unless you are on Elasticsearch
+version 7.8 or higher.
 
 Elasticsearch 7.8+ usage is still experimental. Please contact support if you wish to try upgrading.
 
 ## Synonyms
-For better search relevance and results, a dictionary of synonyms can be very useful in the following cases:
+
+For better search relevance and results, a dictionary of synonyms can be useful in the following cases:
 
 - There are a lot of acronyms or other contractions in your content
 - There are common misspellings of search terms
 - There are users from different countries who may use different words for the same thing
 - There are sub-categories of content that should match a more general search term
 
-For example, you may want search results for the phrase "Checking Accounts" to match content that is titled "Current Accounts" or for common acronyms like "GDP" to match "Gross Domestic Product".
+For example, you may want search results for the phrase "Checking Accounts" to match content that is titled "Current Accounts" or
+for common acronyms like "GDP" to match "Gross Domestic Product".
 
-Additionally, to cater for variations in language, you could create synonyms for American English e.g. "sneakers" to British English e.g. "trainers".
+Additionally, to cater for variations in language, you could create synonyms for American English e.g. "sneakers" to British English
+e.g. "trainers".
 
 Comma-separated lists of words are treated as equivalent. You should have one list of synonyms per line.
 
-```
+```text
 sneakers, trainers, footwear, shoes
 foozball, foosball, table football
 CPU, central processing unit
 ```
 
-Comma-separated words or phrases followed by "=>" will be treated the same as comma-separated words or phrases to the right of the "=>" operator but not the other way around.
+Comma-separated words or phrases followed by "=>" will be treated the same as comma-separated words or phrases to the right of
+the "=>" operator but not the other way around.
 
-```
+```text
 i-pod, i pod => ipod
 tent => bivouac, teepee
 sea biscuit, sea biscit => seabiscuit
 ```
 
-In the above example, a search for "tent" will match content containing "bivouac" or "teepee" but a search for "teepee" will only return results containing the word "teepee" specifically.
-
+In the above example, a search for "tent" will match content containing "bivouac" or "teepee" but a search for "teepee" will only
+return results containing the word "teepee" specifically.
 
 ## Stop Words
-Stop words are words that are ignored when analysing content and searching content. Altis uses the standard dictionary of stop words for each supported language. For example in english this includes "it", "of", "and" and so on.
+
+Stop words are words that are ignored when analysing content and searching content. Altis uses the standard dictionary of stop words
+for each supported language. For example in english this includes "it", "of", "and" and so on.
 
 The default list should be adequate in most cases.
 
 A stop words dictionary should contain one word per line:
 
-```
+```text
 ignore
 these
 words
 ```
 
-
 ## Japanese User Dictionary
+
 Your site's language must be set to Japanese to see this option.
 
-A user dictionary provides a way to control how words are broken up when searching. If there are compound words or phrases specific to your site, such as the names of imaginary places, or authors and celebrities that users may search for, they can be specified here to increase search relevancy.
+A user dictionary provides a way to control how words are broken up when searching. If there are compound words or phrases specific
+to your site, such as the names of imaginary places, or authors and celebrities that users may search for, they can be specified
+here to increase search relevancy.
 
 The syntax for the provided text file should follow the Comma-Separated Values (CSV) format:
 
@@ -92,10 +111,12 @@ text,tokens,readings,part-of-speech
 
 1. `text` is the compound word or phrase that appears in your content, such as a name
 2. `tokens` must contain the same text again with spaces added between each word
-3. `readings` must contain the same text as `tokens` with any kanji replaced by katakana. This describes the pronunciation of the tokens.
+3. `readings` must contain the same text as `tokens` with any kanji replaced by katakana. This describes the pronunciation of the
+   tokens.
 4. `part-of-speech` defines what the text is, for example a noun or verb
 
-By default the text "東京スカイツリー" would be broken up into "東京", "スカイ" and "ツリ". The example below changes this behavior so that the text is treated as a custom noun:
+By default the text "東京スカイツリー" would be broken up into "東京", "スカイ" and "ツリ". The example below changes this behavior
+so that the text is treated as a custom noun:
 
 ```csv
 東京スカイツリー,東京 スカイツリー,トウキョウ スカイツリー,名詞

--- a/docs/configuration/date-decay.md
+++ b/docs/configuration/date-decay.md
@@ -1,24 +1,34 @@
 # Date Decay
 
-The ordering of the results of an Elasticsearch query is done by comparing the weighting score for each post. This score is calculated as a base score:
+The ordering of the results of an Elasticsearch query is done by comparing the weighting score for each post. This score is
+calculated as a base score:
 
-```
+```text
  [ best exact match relevance ] + [ best fuzzy match relevance ]
 ```
 
-... modified by a decay function score representing the staleness of the post.
+… modified by a decay function score representing the staleness of the post.
 
-ElasticPress's default settings are to use a function which returns a float from 0-1, where 1 represents a post updated in the past week, and the score approaches zero quite rapidly - a post published two months ago will be around .15).
+ElasticPress's default settings are to use a function which returns a float from 0-1, where 1 represents a post updated in the past
+week, and the score approaches zero quite rapidly - a post published two months ago will be around .15).
 
-The default setting for "boost mode" - how the decay function is used to modify the base score - is "sum", meaning that this 0-1 value is added to the base score. Since the base scores for exact matches of moderately common search terms (ie terms that appear in 2-3% of posts on a site) can be in the realm of 100-150, adding this decay score has very little impact beyond guaranteeing a consistant order for posts with otherwise identical relevance scores.
+The default setting for "boost mode" - how the decay function is used to modify the base score - is "sum", meaning that this 0-1
+value is added to the base score. Since the base scores for exact matches of moderately common search terms (i.e. terms that
+appear in 2-3% of posts on a site) can be in the realm of 100-150, adding this decay score has little impact beyond
+guaranteeing a consistent order for posts with otherwise identical relevance scores.
 
-For sites that want to prioritize timeliness of results for search queries, using a "boost mode" of "multiply" may be desirable, so that recency of content has a higher impact on search results. Using this, the decay score is a fractional multiplier which ensures that more recent results are prioritized.
+For sites that want to prioritize timeliness of results for search queries, using a "boost mode" of "multiply" may be desirable, so
+that recency of content has a higher impact on search results. Using this, the decay score is a fractional multiplier which ensures
+that more recent results are prioritized.
 
-_(If you want to go deeper into the equations under the hood, the Elasticsearch documentation about [supported decay functions](https://www.elastic.co/guide/en/elasticsearch/reference/7.7/query-dsl-function-score-query.html) is a good place to dig in.)_
+_(If you want to go deeper into the equations under the hood, the Elasticsearch documentation
+about [supported decay functions](https://www.elastic.co/guide/en/elasticsearch/reference/7.7/query-dsl-function-score-query.html)
+is a good place to dig in.)_
 
-Altis Enhanced Search allows for overriding these default values by specifying the values you want to use in the composer.json config object:
+Altis Enhanced Search allows for overriding these default values by specifying the values you want to use in the composer.json
+config object:
 
-```
+```json
 {
     "extra": {
         "altis": {
@@ -37,6 +47,10 @@ Altis Enhanced Search allows for overriding these default values by specifying t
 }
 ```
 
-This configuration creates a date decay algorithm where posts from the past 30 days ("offset") are considered equally current, and for every 30 days in the past ("scale") posts are considered to lose 10% of their relevancy ("decay"). A post from a year ago is weighted about 30% as highly (0.9^12 = .2824) as one from the past week.
+This configuration creates a date decay algorithm where posts from the past 30 days ("offset") are considered equally current, and
+for every 30 days in the past ("scale") posts are considered to lose 10% of their relevancy ("decay"). A post from a year ago is
+weighted about 30% as highly (0.9^12 = .2824) as one from the past week.
 
-A useful correlation by which to understand this score is that exact matches are about 4x more impactful on a post's score as fuzzy matches. Deciding at what age a post which exactly matches the search terms presented is stale enough that it should not outweigh a current post in search results can help to derive the values to use for the decay function.
+A useful correlation by which to understand this score is that exact matches have about 4x more impact on a post's score than do
+fuzzy matches. Deciding at what age a post which exactly matches the search terms presented is stale enough that it should not
+outweigh a current post in search results can help to derive the values to use for the decay function.

--- a/docs/configuration/tuning.md
+++ b/docs/configuration/tuning.md
@@ -2,26 +2,28 @@
 
 Altis provides a set of default configuration for relevancy scoring based on experience and customer feedback.
 
-Depending on your use case and requirements, you may wish to tune relevancy to provide more relevant results to visitors. The following built-in configuration options aim to provide some high-level levers for tuning.
+Depending on your use case and requirements, you may wish to tune relevancy to provide more relevant results to visitors. The
+following built-in configuration options aim to provide some high-level levers for tuning.
 
-**Note:** Relevancy scoring is a highly subjective process, and Altis support cannot assist with this except for clearly identified bugs. The Altis team can help you find partners with Elasticsearch experience if needed.
-
+**Note:** Relevancy scoring is a highly subjective process, and Altis support cannot assist with this except for clearly identified
+bugs. The Altis team can help you find partners with Elasticsearch experience if needed.
 
 ## Search Mode
 
-The mode setting determines whether or not the search will allow the use of advanced search syntax. The default mode is "simple" search. To enable advanced mode you would use the configuration below.
+The mode setting determines whether or not the search will allow the use of advanced search syntax. The default mode is "simple"
+search. To enable advanced mode you would use the configuration below.
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"modules": {
-				"search": {
-					"mode": "advanced"
-				}
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "modules": {
+                "search": {
+                    "mode": "advanced"
+                }
+            }
+        }
+    }
 }
 ```
 
@@ -34,73 +36,83 @@ By setting `mode` to "advanced" it is possible to write more complex search term
 - A word followed by `*` will match anything with that prefix
 - A word preceded by `-` will be excluded from the results
 
-For example the following search would return results with exact matches for "the law", or the words "judge" and "dredd" and excluding the word "marvel".
+<!-- vale Vale.Spelling = NO -->
+For example the following search would return results with exact matches for "the law", or the words "judge" and "dredd" and
+excluding the word "marvel".
+<!-- vale Vale.Spelling = YES -->
 
-```
+```text
 "the law" OR (judge AND dredd) -marvel
 ```
-
 
 ## Strict Search
 
 By default searching will match _all_ the provided search terms.
 
-This means the more specific a search query is the fewer results will be provided. For example "the quick brown fox" will be interpreted as "the `AND` quick `AND` brown `AND` fox".
+This means the more specific a search query is the fewer results will be provided. For example "the quick brown fox" will be
+interpreted as "the `AND` quick `AND` brown `AND` fox".
 
-Setting `strict` to `false` will change the behaviour to match each individual word as well as the full search query, with complete matches being scored more highly.
+Setting `strict` to `false` will change the behaviour to match each individual word as well as the full search query, with complete
+matches being scored more highly.
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"modules": {
-				"search": {
-					"strict": false
-				}
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "modules": {
+                "search": {
+                    "strict": false
+                }
+            }
+        }
+    }
 }
 ```
 
-Strict matching is recommended if you have a user interface that allows sorting search results by anything other than relevance such as date.
-
+Strict matching is recommended if you have a user interface that allows sorting search results by anything other than relevance such
+as date.
 
 ## Field Boosting
 
-By default the post title, excerpt, content, author name and taxonomy terms are searched against. Field boosting allows you to modify the importance of those fields with regards to search results. The following configuration will increase the important of the post title, excerpt and a custom meta field above the default value of 1.
+By default the post title, excerpt, content, author name and taxonomy terms are searched against. Field boosting allows you to
+modify the importance of those fields with regards to search results. The following configuration will increase the important of the
+post title, excerpt and a custom meta field above the default value of 1.
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"modules": {
-				"search": {
-					"field-boost": {
-						"post_title": 3,
-						"post_excerpt": 2,
-						"meta.custom_field.value": 2
-					}
-				}
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "modules": {
+                "search": {
+                    "field-boost": {
+                        "post_title": 3,
+                        "post_excerpt": 2,
+                        "meta.custom_field.value": 2
+                    }
+                }
+            }
+        }
+    }
 }
 ```
 
-It is important to note that the field names should match the fields in the elasticsearch index and do not always correspond 1:1 with database fields.
-
+It is important to note that the field names should match the fields in the Elasticsearch index and do not always correspond 1:1
+with database fields.
 
 ## Fuzzy Matching
 
-By default some degree of fuzzy matching is allowed so that simple spelling errors can still return some results, for example "breif" would match "brief". This can sometimes result in unwanted search results however with short words and acronyms.
+<!-- vale Vale.Spelling = NO -->
+By default some degree of fuzzy matching is allowed so that simple spelling errors can still return some results, for example "
+breif" would match "brief". This can sometimes result in unwanted search results however with short words and acronyms.
+<!-- vale Vale.Spelling = YES -->
 
-Fuzzy matching works by providing an _edit distance_ as an integer from 0-2. The number indicates how many edits are allowed for a term to match. Edits can be one of the following:
+Fuzzy matching works by providing an _edit distance_ as an integer from 0-2. The number indicates how many edits are allowed for a
+term to match. Edits can be one of the following:
 
-* Changing a character (box → fox)
-* Removing a character (click → lick)
-* Inserting a character (sic → sick)
-* Transposing two adjacent characters (act → cat)
+- Changing a character (box → fox)
+- Removing a character (click → lick)
+- Inserting a character (sic → sick)
+- Transposing two adjacent characters (act → cat)
 
 **Note:** when using "advanced" search mode quoted strings will not use fuzzy matching.
 
@@ -110,28 +122,31 @@ Below is the default fuzzy search configuration.
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"modules": {
-				"search": {
-					"fuzziness": {
-						"distance": "auto:4,7",
-						"prefix-length": 1,
-						"max-expansions": 40,
-						"transpositions": true
-					}
-				}
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "modules": {
+                "search": {
+                    "fuzziness": {
+                        "distance": "auto:4,7",
+                        "prefix-length": 1,
+                        "max-expansions": 40,
+                        "transpositions": true
+                    }
+                }
+            }
+        }
+    }
 }
 ```
 
 **`distance`**
 
-This is the [Elasticsearch fuzziness value](https://www.elastic.co/guide/en/elasticsearch/reference/6.3/common-options.html#fuzziness) and determines the maximum edit distance for fuzzy matching. This value can also be set as the value for `fuzziness` directly if you do not need to edit the other options.
+This is
+the [Elasticsearch fuzziness value](https://www.elastic.co/guide/en/elasticsearch/reference/6.3/common-options.html#fuzziness) and
+determines the maximum edit distance for fuzzy matching. This value can also be set as the value for `fuzziness` directly if you do
+not need to edit the other options.
 
-- If an integer is provided this is used as a fixed edit distance eg. 0, 1 or 2 edits allowed
+- If an integer is provided this is used as a fixed edit distance e.g. 0, 1 or 2 edits allowed
 - If a string is provided it must be in the form `auto:[min],[max]`
   - If `min` is 3 all terms from 0-2 characters long will have an edit distance of 0
   - If `max` is 6 all terms from `min` to 6 characters long will have an edit distance of 1
@@ -139,22 +154,28 @@ This is the [Elasticsearch fuzziness value](https://www.elastic.co/guide/en/elas
 
 **`prefix-length`**
 
-This value determines how many characters at the start of a search term must match before fuzzy matching is applied. For instance a prefix length of 1 will mean that "lotion" will match "lotoin" but not "potion" or "motion".
+<!-- vale Vale.Spelling = NO -->
+This value determines how many characters at the start of a search term must match before fuzzy matching is applied. For instance a
+prefix length of 1 will mean that "lotion" will match "lotoin" but not "potion" or "motion".
+<!-- vale Vale.Spelling = YES -->
 
 **`max-expansions`**
 
-This value is the number of fuzzy terms generated from a search term when used for matching. Higher values will result in slower searches but more matches and lower values will result in faster searches but fewer matches.
+This value is the number of fuzzy terms generated from a search term when used for matching. Higher values will result in slower
+searches but more matches and lower values will result in faster searches but fewer matches.
 
 If you have a prefix length of 0 you may wish to increase this value to get more matches.
 
 **`transpositions`**
 
-This option allows you to prevent transpositions from being counted as a single edit. In the above example the transposition "act" to "cat" has an edit distance of 1. Setting this value to `false` would mean the same transposition would have an edit distance of 2 because 2 letters have been replaced.
-
+This option allows you to prevent transpositions from being counted as a single edit. In the above example the transposition "act"
+to "cat" has an edit distance of 1. Setting this value to `false` would mean the same transposition would have an edit distance of 2
+because 2 letters have been replaced.
 
 ## Max Query Length
 
-Typically search queries can be as long as the user wishes. As a preventative measure against slow queries and search request spamming, Altis limits search query strings to **100 characters** by default.
+Typically search queries can be as long as the user wishes. As a preventive measure against slow queries and search request
+spamming, Altis limits search query strings to **100 characters** by default.
 
 You can configure this value in 2 ways.
 
@@ -162,15 +183,15 @@ Using the Altis Search config option `max-query-length`:
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"modules": {
-				"search": {
-					"max-query-length": 150
-				}
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "modules": {
+                "search": {
+                    "max-query-length": 150
+                }
+            }
+        }
+    }
 }
 ```
 
@@ -180,21 +201,21 @@ Note that the filter method will take precedence and can be used for applying co
 
 ```php
 add_filter( 'altis.search.max_query_length', function ( int $max_length, string $search ) {
-	// Allow long search strings in the admin.
-	if ( is_admin() ) {
-		return 1000;
-	}
+    // Allow long search strings in the admin.
+    if ( is_admin() ) {
+        return 1000;
+    }
 
-	// Allow long search queries if they are URLs.
-	if ( preg_match( '#https?://[a-z0-9/_-.]+#', $search ) ) {
-		return mb_strlen( $search );
-	}
+    // Allow long search queries if they are URLs.
+    if ( preg_match( '#https?://[a-z0-9/_-.]+#', $search ) ) {
+        return mb_strlen( $search );
+    }
 
-	return 50;
+    return 50;
 } );
 ```
 
-
 ## Date Decay
 
-For most use cases, you'll want to treat newer results as more relevant than older ones. Altis includes [date decay functionality](./date-decay.md) which automatically adjusts relevancy scores based on dates.
+For most use cases, you'll want to treat newer results as more relevant than older ones. Altis
+includes [date decay functionality](./date-decay.md) which automatically adjusts relevancy scores based on dates.

--- a/docs/elasticsearch-specifications.md
+++ b/docs/elasticsearch-specifications.md
@@ -1,7 +1,7 @@
 # Elasticsearch Specifications
 
-Altis Cloud environments include Elasticsearch servers which are used by the Search module. An equivalent setup is also available with [Local Server](docs://local-server/)
-
+Altis Cloud environments include Elasticsearch servers which are used by the Search module. An equivalent setup is also available
+with [Local Server](docs://local-server/)
 
 ## Supported Versions
 
@@ -11,10 +11,10 @@ The following versions of Elasticsearch are supported:
 - 6.8
 - 6.3
 
-We recommended using the most up-to-date version wherever possible, as new versions come with significant performance improvements as well as additional capabilities.
+We recommended using the most up-to-date version wherever possible, as new versions come with significant performance improvements
+as well as additional capabilities.
 
 You can [request an Elasticsearch upgrade](docs://guides/updating-elasticsearch/) to switch to a specific version.
-
 
 ## Supported Elasticsearch Plugins
 
@@ -23,7 +23,7 @@ The following Elasticsearch plugins are available on Cloud and Local environment
 - ICU Analysis
 - Ingest Attachment Processor
 - Ingest User Agent Processor
-- Japanese (kuromoji) Analysis
+- Japanese (Kuromoji) Analysis
 - Mapper Murmur3
 - Mapper Size
 - Phonetic Analysis
@@ -32,9 +32,10 @@ The following Elasticsearch plugins are available on Cloud and Local environment
 - Ukrainian Analysis
 - Seunjeon Korean Analysis
 
-
 ## Storage, CPU, and Memory
 
-Just like other components of your Altis Cloud environments, the Altis team automatically manages storage, CPU, and memory for Elasticsearch on your behalf.
+Just like other components of your Altis Cloud environments, the Altis team automatically manages storage, CPU, and memory for
+Elasticsearch on your behalf.
 
-If you have specific higher requirements, contact Altis Support to discuss increasing your provisioned environment. Please note that additional charges may apply for usage exceeding that of similarly-situated customers.
+If you have specific higher requirements, contact Altis Support to discuss increasing your provisioned environment. Please note that
+additional charges may apply for usage exceeding that of similarly-situated customers.

--- a/docs/indexing/README.md
+++ b/docs/indexing/README.md
@@ -2,8 +2,8 @@
 
 The indexing process is how Altis adds, updates, and deletes data in your Elasticsearch indexes.
 
-Altis automatically indexes your content as it changes to keep search indexes in sync with the original data stored in the database. Data can also be [manually indexed via re-indexing](reindexing.md).
-
+Altis automatically indexes your content as it changes to keep search indexes in sync with the original data stored in the database.
+Data can also be [manually indexed via re-indexing](reindexing.md).
 
 ## Data Types and Fields
 
@@ -26,14 +26,18 @@ The following data is not indexed by default but can be enabled via your config:
 - Comments
 - Comment Meta
 
-**Note:** Post meta that is "protected" - i.e. has a key beginning with `_` - will not be indexed automatically. To index these fields, use the `ep_prepare_meta_allowed_protected_keys` filter. It will accept a value of boolean `true` (which will index *all* protected meta) or an array containing the keys of specific protected meta fields you want to index.
+**Note:** Post meta that is "protected" - i.e. has a key beginning with `_` - will not be indexed automatically. To index these
+fields, use the `ep_prepare_meta_allowed_protected_keys` filter. It will accept a value of boolean `true` (which will index *all*
+protected meta) or an array containing the keys of specific protected meta fields you want to index.
 
-When used in conjunction with the [Media Rekognition](docs://media/image-recognition.md) feature, all images are processed for automatic keyword detection and stored in the search index too.
-
+When used in conjunction with the [Media Rekognition](docs://media/image-recognition.md) feature, all images are processed for
+automatic keyword detection and stored in the search index too.
 
 ## Document Indexing
 
-All documents that are uploaded to the media library can also be parsed and indexed. For example, if you upload a PDF file, the PDF content will be read and included in the search index. Searches for keywords and phrases that are included in the document will be then be included in search results.
+All documents that are uploaded to the media library can also be parsed and indexed. For example, if you upload a PDF file, the PDF
+content will be read and included in the search index. Searches for keywords and phrases that are included in the document will be
+then be included in search results.
 
 The following document types are parsed and their content is added to the search index:
 

--- a/docs/indexing/additional-data.md
+++ b/docs/indexing/additional-data.md
@@ -2,23 +2,26 @@
 
 ## Storing Additional Data
 
-The default search index will include all post data, such as content, author, title, date, meta and terms. There are situations where you may want to add custom data, for example: suppose you want to support search for content based on a custom relationship to another post.
+The default search index will include all post data, such as content, author, title, date, meta and terms. There are situations
+where you may want to add custom data, for example: suppose you want to support search for content based on a custom relationship to
+another post.
 
-In this case, you would modify the data for a all posts before the data is sent to the search index for storage. To do so, add your extra data via the `ep_post_sync_args_post_prepare_meta` filter.
+In this case, you would modify the data for a all posts before the data is sent to the search index for storage. To do so, add your
+extra data via the `ep_post_sync_args_post_prepare_meta` filter.
 
 ```php
 add_filter( 'ep_post_sync_args_post_prepare_meta', function ( array $post_data, int $post_id ) : array {
 
-	// This filter is called for all post types, so only add data to our "events" post type.
-	if ( $post_data['post_type'] !== 'events' ) {
-		return $post_data;
-	}
+    // This filter is called for all post types, so only add data to our "events" post type.
+    if ( $post_data['post_type'] !== 'events' ) {
+        return $post_data;
+    }
 
-	// Get the country name from the country ID stored in post meta.
-	$country = event_get_country( get_post_meta( 'country_id', $post_id, true ) );
-	$post_data['country'] = $country->get_name();
+    // Get the country name from the country ID stored in post meta.
+    $country = event_get_country( get_post_meta( 'country_id', $post_id, true ) );
+    $post_data['country'] = $country->get_name();
 
-	return $post_data;
+    return $post_data;
 }, 10, 2 );
 ```
 

--- a/docs/indexing/reindexing.md
+++ b/docs/indexing/reindexing.md
@@ -1,16 +1,17 @@
 # Setup and Reindexing
 
-Altis automatically indexes your content as it changes to keep search indexes in sync with the original data stored in the database. However, some manual steps may need to be performed.
-
+Altis automatically indexes your content as it changes to keep search indexes in sync with the original data stored in the database.
+However, some manual steps may need to be performed.
 
 ## Setup
 
-Before data can be indexed, the index "mapping" must be created. This works like a table definition in MySQL, containing a list of fields, their data types, and any field settings. The index mappings can be created by running `wp elasticpress put-mapping`.
-
+Before data can be indexed, the index "mapping" must be created. This works like a table definition in MySQL, containing a list of
+fields, their data types, and any field settings. The index mappings can be created by running `wp elasticpress put-mapping`.
 
 ## Verifying Mappings
 
-To verify one or all Elasticsearch mappings are as expected, you can use the `wp elasticpress get-mapping` subcommand. The command will print all mappings as a JSON string, which is in line with how index data is provided.
+To verify one or all Elasticsearch mappings are as expected, you can use the `wp elasticpress get-mapping` sub-command. The command
+will print all mappings as a JSON string, which is in line with how index data is provided.
 
 By passing an optional index name, the response includes mappings for that index only:
 
@@ -18,7 +19,8 @@ By passing an optional index name, the response includes mappings for that index
 wp elasticpress get-mapping --index-name=ep-mysitealtisdev-post-1
 ```
 
-To format this in a human-readable way, you may want to pipe the output to a script that allows for pretty-printing JSON, for example, like so:
+To format this in a human-readable way, you may want to pipe the output to a script that allows for pretty-printing JSON, for
+example, like so:
 
 - `wp elasticpress get-mapping | jq .` (see [`jq`](https://stedolan.github.io/jq/))
 - `wp elasticpress get-mapping | json` (see [`json`](https://trentm.com/json/))
@@ -29,12 +31,13 @@ This also works when executing the WP-CLI command within [Local Server](docs://l
 composer server cli -- elasticpress get-mapping | jq .
 ```
 
-
 ## Reindexing
 
-Occasionally, a "reindex" may be required. This can occur if data is out of sync in Elasticsearch, if data is updated directly in the database, or when conducting imports.
+Occasionally, a "reindex" may be required. This can occur if data is out of sync in Elasticsearch, if data is updated directly in
+the database, or when conducting imports.
 
-When making changes the data or analyzers that are stored in the search index, you must re-index the content so all results and search operations are using the new data specification.
+When making changes the data or analyzers that are stored in the search index, you must re-index the content so all results and
+search operations are using the new data specification.
 
 Re-indexing is done via CLI commands, as they are potentially long running, high memory usage tasks. To reindex a site, run:
 
@@ -42,12 +45,13 @@ Re-indexing is done via CLI commands, as they are potentially long running, high
 wp elasticpress sync
 ```
 
-**Note:** During the indexing process, the site will not use the Elasticsearch index for searches/queries, so some features like faceting or autosuggest will not work as expected until the process is finished.
-
+**Note:** During the indexing process, the site will not use the Elasticsearch index for searches/queries, so some features like
+faceting or autosuggest will not work as expected until the process is finished.
 
 ## Recreating Mappings
 
-If your index mapping changes, the mapping will need to be recreated. This may be needed after an Altis upgrade, when adjusting index settings via filters, or changing language settings.
+If your index mapping changes, the mapping will need to be recreated. This may be needed after an Altis upgrade, when adjusting
+index settings via filters, or changing language settings.
 
 To re-sychronise the index and update mappings, run:
 
@@ -55,7 +59,9 @@ To re-sychronise the index and update mappings, run:
 wp elasticpress sync --setup
 ```
 
-To run across the entire network, use `xargs` with the above command. Given that the user index is a global one, it will be recreated for every single site. This is unnecessary, so you should only recreate this for one (the main) site. You'll also need to create the "network alias", which is a special index which allows cross-site searching.
+To run across the entire network, use `xargs` with the above command. Given that the user index is a global one, it will be
+recreated for every single site. This is unnecessary, so you should only recreate this for one (the main) site. You'll also need to
+create the "network alias", which is a special index which allows cross-site searching.
 
 Overall, this would look like so:
 
@@ -65,16 +71,19 @@ wp site list --field=url | xargs -I % wp elasticpress sync --url=% --setup --ind
 
 If you have enhanced search enabled for comments as well, you may want to add `comment` to `--indexables`.
 
-**Note:** Changing the mapping requires deleting the index and recreating it, which will remove all existing documents from your index. Performing this process may take significant time.
-
+**Note:** Changing the mapping requires deleting the index and recreating it, which will remove all existing documents from your
+index. Performing this process may take significant time.
 
 ## CLI Recommendations
 
 ### Performing across a Network
 
-When performing these tasks across your whole network, we recommend against using the `--network-wide` flag provided by ElasticPress. When using the `--network-wide` flag on sufficiently large networks, the CLI process may run out of memory and be killed by the operating system. 
+When performing these tasks across your whole network, we recommend against using the `--network-wide` flag provided by
+ElasticPress. When using the `--network-wide` flag on sufficiently large networks, the CLI process may run out of memory and be
+killed by the operating system.
 
-To better manage memory, it is recommended to use an `xargs` pipeline to process each site. `wp site list --field=url` will print each site URL on a new line, which can then be ingested by `xargs` to be processed individually.
+To better manage memory, it is recommended to use an `xargs` pipeline to process each site. `wp site list --field=url` will print
+each site URL on a new line, which can then be ingested by `xargs` to be processed individually.
 
 To perform a reindex across all sites:
 
@@ -90,10 +99,10 @@ wp site list --field=url | xargs -I % wp elasticpress sync --url=% --setup --ind
 
 This also recreates the "network alias", which is a special index which allows cross-site searching.
 
-
 ### Limiting Page Size
 
-When using CLI to perform re-indexes, it's recommended to set the `--per-page` argument to a figure around `200`. By default, this figure is set to `350` which will often cause service timeouts. For example:
+When using CLI to perform re-indexes, it's recommended to set the `--per-page` argument to a figure around `200`. By default, this
+figure is set to `350` which will often cause service timeouts. For example:
 
 ```sh
 wp site list --field=url | xargs -I % wp elasticpress sync --url=% --per-page=200
@@ -103,4 +112,5 @@ See `wp help elasticpress` for all available CLI commands.
 
 ### Session Time Limits
 
-To ensure your [CLI Session doesn't time out](https://docs.altis-dxp.com/cloud/dashboard/cli/#session-timelimits), it is recommended to create a new `screen` session to run reindexing operations.
+To ensure your [CLI Session doesn't time out](https://docs.altis-dxp.com/cloud/dashboard/cli/#session-timelimits), it is recommended
+to create a new `screen` session to run reindexing operations.

--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -1,6 +1,7 @@
 # Supported languages
 
-By default search terms will be analyzed based on the the site's primary language setting as defined on the [general settings page](internal://admin/options-general.php) in the admin.
+By default search terms will be analyzed based on the site's primary language setting as defined on
+the [general settings page](internal://admin/options-general.php) in the admin.
 
 Altis includes analyzers for the following languages:
 
@@ -44,9 +45,10 @@ Altis includes analyzers for the following languages:
 - Thai
 - Ukrainian
 
-**Note:** Altis Support cannot provide assistance with tuning relevancy scores, or language analysis in languages other than English. Altis Partners may be able to provide consultation for these languages; contact your account manager for more information.
-
+**Note:** Altis Support cannot provide assistance with tuning relevancy scores, or language analysis in languages other than
+English. Altis Partners may be able to provide consultation for these languages; contact your account manager for more information.
 
 ## Japanese
 
-The Search module includes the Japanese language analyzer (kuromoji), as well as the [custom user dictionary tools](./configuration/custom-dictionaries.md) designed specifically for Japanese support.
+The Search module includes the Japanese language analyzer (Kuromoji), as well as the [custom user dictionary tools](.
+/configuration/custom-dictionaries.md) designed specifically for Japanese support.

--- a/docs/querying/README.md
+++ b/docs/querying/README.md
@@ -2,16 +2,15 @@
 
 The querying process is how Altis finds and fetches data from your Elasticsearch indexes.
 
-
 ## Automatic CMS Integration
 
-Altis [integrates with queries in the CMS by default](cms-integration.md), transparently sending search queries to Elasticsearch while leaving other queries unaffected.
-
+Altis [integrates with queries in the CMS by default](cms-integration.md), transparently sending search queries to Elasticsearch
+while leaving other queries unaffected.
 
 ## Autosuggest
 
-Altis also provides [support for Ajax-based autosuggestions](autosuggest.md) which automatically integrate with search forms on your site.
-
+Altis also provides [support for Ajax-based autosuggestions](autosuggest.md) which automatically integrate with search forms on your
+site.
 
 ## Custom Queries
 
@@ -19,7 +18,8 @@ For advanced usage, you can perform [custom queries against the Elasticsearch in
 
 **Note:** Altis cannot provide support for custom queries directly against Elasticsearch.
 
-
 ## Using Google Analytics (GA)
 
-Google Analytics can be configured to ingest search queries for further analysis and insights. This will inform future weightings and search configuration modifications. When configuring GA, the default query parameter value is `s`, see [Google Analytics - Set up Site Search](https://support.google.com/analytics/answer/1012264) for more information.
+Google Analytics can be configured to ingest search queries for further analysis and insights. This will inform future weightings
+and search configuration modifications. When configuring GA, the default query parameter value is `s`,
+see [Google Analytics - Set up Site Search](https://support.google.com/analytics/answer/1012264) for more information.

--- a/docs/querying/autosuggest.md
+++ b/docs/querying/autosuggest.md
@@ -1,31 +1,35 @@
 # Autosuggest
 
-The Search module provides autosuggest functionality, which automatically integrates with search forms on the website to show a dropdown list of suggestions as users type.
+The Search module provides autosuggest functionality, which automatically integrates with search forms on the website to show a
+dropdown list of suggestions as users type.
 
 (This feature is provided by ElasticPress, with additions from Altis.)
-
 
 ## How autosuggest works
 
 Autosuggest works by finding search forms on your site and automatically integrating with these.
 
-Using the element selector specified within the search configuration, ElasticPress JS listens for user input on search forms. As the user types, an Ajax request is sent to the backend to query for possible results.
+Using the element selector specified within the search configuration, ElasticPress JS listens for user input on search forms. As the
+user types, an Ajax request is sent to the backend to query for possible results.
 
-[Just like with other queries](cms-query-integration.md), ElasticPress automatically generates an Elasticsearch query based on the WordPress query being run.
+[Just like with other queries](cms-query-integration.md), ElasticPress automatically generates an Elasticsearch query based on the
+WordPress query being run.
 
-Unlike regular searches, autosuggestion operates on a fuzzy basis, as it needs to match against partial inputs as the user types. ElasticPress automatically converts certain fields in the search into fuzzy search fields for this reason. Additionally, as the query is run based on user input from the frontend, restrictions are applied to ensure only public information is made available.
-
+Unlike regular searches, autosuggestion operates on a fuzzy basis, as it needs to match against partial inputs as the user types.
+ElasticPress automatically converts certain fields in the search into fuzzy search fields for this reason. Additionally, as the
+query is run based on user input from the frontend, restrictions are applied to ensure only public information is made available.
 
 ## Specifying autosuggest behaviour
 
-In the same way as `ep_integrate` can be passed to any query class, you can pass the parameter `autosuggest` along with the `s` parameter (or `search` for user and term queries):
+In the same way as `ep_integrate` can be passed to any query class, you can pass the parameter `autosuggest` along with the `s`
+parameter (or `search` for user and term queries):
 
 ```php
 $posts = new WP_Query( [
-	'autosuggest' => true,
-	// A partial search term.
-	// Setting `s` will cause `ep_integrate` to be added and set to true.
-	's' => 'str',
+    'autosuggest' => true,
+    // A partial search term.
+    // Setting `s` will cause `ep_integrate` to be added and set to true.
+    's' => 'str',
 ] );
 ```
 
@@ -36,62 +40,66 @@ The `autosuggest` parameter defaults to true in the following circumstances:
 - User searches
 - Term searches
 
-
 ## Modifying autosuggest behaviour
 
 ### Element selector
 
-By default, ElasticPress will listen on `.ep-autosuggest`, `input[type="search"]`, and `.search-field` elements. This will match the built-in search widget and search form block.
+By default, ElasticPress will listen on `.ep-autosuggest`, `input[type="search"]`, and `.search-field` elements. This will match the
+built-in search widget and search form block.
 
-In some cases, this can interfere with other inputs on your site. This behaviour can be changed to match your theme by filtering the `ep_autosuggest_default_selectors` filter:
+In some cases, this can interfere with other inputs on your site. This behaviour can be changed to match your theme by filtering
+the `ep_autosuggest_default_selectors` filter:
 
 ```php
 add_filter( 'ep_autosuggest_default_selectors', function ( string $selectors ) {
-	return '.my-search-input, input[type="search"].autosuggest';
+    return '.my-search-input, input[type="search"].autosuggest';
 } );
 ```
 
-
 ### Altering search fields
 
-By default, autosuggest will search against fields in the same way as a [regular search query](cms-query-integration.md). In addition, fuzziness is applied to the fields using an ngram model to account for partial inputs.
+By default, autosuggest will search against fields in the same way as a [regular search query](cms-query-integration.md). In
+addition, fuzziness is applied to the fields using an n-gram model to account for partial inputs.
 
-By default only a subset of fields are analysed for autosuggest searches, but this can be filtered to add additional fields for each indexable object type.
+By default only a subset of fields are analysed for autosuggest searches, but this can be filtered to add additional fields for each
+indexable object type.
 
 **`altis.search.autosuggest_post_fields : array`** defaults to `post_title`.
 
 **`altis.search.autosuggest_term_fields : array`** defaults to `name`.
 
-**`altis.search.autosuggest_user_fields : array`** defaults to `user_nicename`, `display_name`, `user_login`, `meta.first_name.value`, `meta.last_name.value` and `meta.nickname.value`.
+**`altis.search.autosuggest_user_fields : array`** defaults
+to `user_nicename`, `display_name`, `user_login`, `meta.first_name.value`, `meta.last_name.value` and `meta.nickname.value`.
 
 **Note:** if the above filters are used the site content will need to be re-indexed for autosuggestions to work properly.
 
-
 ### Modifying the query
 
-Autosuggest queries can be modified using the low-level `altis.search.autosuggest_query` filter, which provides the full Elasticsearch query.
+Autosuggest queries can be modified using the low-level `altis.search.autosuggest_query` filter, which provides the full
+Elasticsearch query.
 
 For example, to exclude any posts with post meta of `_hide` set to `1`:
 
 ```php
 add_filter( 'altis.search.autosuggest_query', function ( array $query ) : array {
-	$query['post_filter']['bool']['must_not'] = [
-		[ 'term' => [ 'post.meta._hide.raw' => '1' ] ]
-	];
-	return $query;
+    $query['post_filter']['bool']['must_not'] = [
+        [ 'term' => [ 'post.meta._hide.raw' => '1' ] ]
+    ];
+    return $query;
 } );
 ```
 
-As autosuggest queries are sent from the client side, the `post_filter` part of the query is hardcoded to only allow publicly searchable posts with the status `publish` to be returned.
+As autosuggest queries are sent from the client side, the `post_filter` part of the query is hard coded to only allow publicly
+searchable posts with the status `publish` to be returned.
 
 To alter this behaviour, you can manually override the field via the `altis.search.autosuggest_query` filter:
 
 ```php
 add_filter( 'ep_term_suggest_post_status', function ( array $query ) : array {
-	$query['post_filter']['bool']['must'][0]['term']['post_status'] = [
-		'publish',
-		'my_custom_status',
-	];
-	return $query;
+    $query['post_filter']['bool']['must'][0]['term']['post_status'] = [
+        'publish',
+        'my_custom_status',
+    ];
+    return $query;
 } );
 ```

--- a/docs/querying/cms-integration.md
+++ b/docs/querying/cms-integration.md
@@ -1,72 +1,79 @@
 # CMS Integration
 
-The Search module automatically integrates with the search functionality in the CMS, transparently upgrading requests to use Elasticsearch where possible.
+The Search module automatically integrates with the search functionality in the CMS, transparently upgrading requests to use
+Elasticsearch where possible.
 
 (This feature is provided by ElasticPress, with additions from Altis.)
 
-
 ## Querying with ElasticPress
 
-By default, all search operations using the query APIs will transparently make use of the search index. This includes `WP_Query`, `WP_User_Query`, `WP_Term_Query`, and REST API queries, **where the search parameter is specified** (typically `s`).
+By default, all search operations using the query APIs will transparently make use of the search index. This
+includes `WP_Query`, `WP_User_Query`, `WP_Term_Query`, and REST API queries, **where the search parameter is specified** (
+typically `s`).
 
-You may want to manually enable this behaviour to use the search index for non-search queries. This may improve performance when running complex queries, such as meta queries, that would otherwise be too slow to do in the database.
+You may want to manually enable this behaviour to use the search index for non-search queries. This may improve performance when
+running complex queries, such as meta queries, that would otherwise be too slow to do in the database.
 
-**Note:** This usage is advanced, and may have wide-ranging implications for your queries, as you're querying the indexed fields rather than the original, source fields. Ensure you test this behaviour extensively.
+**Note:** This usage is advanced, and may have wide-ranging implications for your queries, as you're querying the indexed fields
+rather than the original, source fields. Ensure you test this behaviour extensively.
 
-To enable the use of ElasticPress integration, set the `ep_integrate` query param to `true`. (If the `s` (search) parameter is present `ep_integrate` will be set to `true` automatically.)
+To enable the use of ElasticPress integration, set the `ep_integrate` query parameter to `true`. (If the `s` (search) parameter is
+present `ep_integrate` will be set to `true` automatically.)
 
-For example, the following query finds projects based on meta value, but does not contain search parameters. By default, ElasticPress would not be used, but is enabled explicitly by setting `ep_integrate` to `true`.
+For example, the following query finds projects based on meta value, but does not contain search parameters. By default,
+ElasticPress would not be used, but is enabled explicitly by setting `ep_integrate` to `true`.
 
 ```php
 $posts = new WP_Query( [
-	'ep_integrate' => true, // Use Elasticsearch.
-	'post_type' => 'project',
-	'meta_query' => [
-		[
-			'key' => 'color',
-			'value' => [ 'blue', 'green' ],
-			'compare' => 'IN'
-		],
-	],
+    'ep_integrate' => true, // Use Elasticsearch.
+    'post_type' => 'project',
+    'meta_query' => [
+        [
+            'key' => 'color',
+            'value' => [ 'blue', 'green' ],
+            'compare' => 'IN'
+        ],
+    ],
 ] );
 ```
 
-**Note:** This example may trigger [Automated Code Review](docs://guides/code-review/README.md) warnings due to the use of a meta query. While meta queries have a lower performance impact with Elasticsearch, it's important to test performance characteristics.
+**Note:** This example may trigger [Automated Code Review](docs://guides/code-review/README.md) warnings due to the use of a meta
+query. While meta queries have a lower performance impact with Elasticsearch, it's important to test performance characteristics.
 
-The automatic integration can be disabled on a per query basis by explicitly setting `ep_integrate` to false in the query arguments or on the `pre_get_posts` action. For example:
+The automatic integration can be disabled on a per query basis by explicitly setting `ep_integrate` to false in the query arguments
+or on the `pre_get_posts` action. For example:
 
 ```php
 add_action( 'pre_get_posts', function ( WP_Query $query ) {
-	// Avoid using Elasticsearch for the 'project' post type.
-	if ( $query->is_search() && $query->get( 'post_type' ) === 'project' ) {
-		$query->set( 'ep_integrate', false );;
-	}
+    // Avoid using Elasticsearch for the 'project' post type.
+    if ( $query->is_search() && $query->get( 'post_type' ) === 'project' ) {
+        $query->set( 'ep_integrate', false );;
+    }
 } );
 ```
 
-
 ## Customising Searched Fields
 
-Altis will search key content fields by default, including those defined in the [field boosting config](../search-configuration/README.md#field-boosting), depending on the type of content.
-
+Altis will search key content fields by default, including those defined in
+the [field boosting config](../search-configuration/README.md#field-boosting), depending on the type of content.
 
 ### Using Query Parameters
 
-`WP_Query`, `WP_Term_Query` and `WP_User_Query` support a `search_fields` parameter. This can be used to override the default searched fields and even to modify how the fields are boosted using the `<field>^<boost value>` syntax.
+`WP_Query`, `WP_Term_Query` and `WP_User_Query` support a `search_fields` parameter. This can be used to override the default
+searched fields and even to modify how the fields are boosted using the `<field>^<boost value>` syntax.
 
 ```php
 $posts = new WP_Query( [
-	'ep_integrate' => true, // Use Elasticsearch.
-	'post_type' => 'project',
-	'search_fields' => [
-		'post_title',
-		'meta.client.value^2',
-	],
+    'ep_integrate' => true, // Use Elasticsearch.
+    'post_type' => 'project',
+    'search_fields' => [
+        'post_title',
+        'meta.client.value^2',
+    ],
 ] );
 ```
 
 When using the `search_fields` parameter, the `ep_search_fields` filter will be run which can modify the list of searched fields.
-
 
 ### Using Filters
 
@@ -74,38 +81,40 @@ As noted above the `ep_search_fields` filter can be used to further customise qu
 
 ```php
 add_filter( 'ep_search_fields', function ( array $fields ) : array {
-	$fields[] = 'alt';
-	$fields[] = 'meta.keywords.value';
-	return $fields;
+    $fields[] = 'alt';
+    $fields[] = 'meta.keywords.value';
+    return $fields;
 } );
 ```
 
-To modify the default searchable fields (when the `search_fields` parameter is _not_ used) you need to use the `ep_weighting_default_post_type_weights` filter. The filter has 2 parameters, a keyed array of fields including their enabled status and weight, and the post type.
+To modify the default searchable fields (when the `search_fields` parameter is _not_ used) you need to use
+the `ep_weighting_default_post_type_weights` filter. The filter has 2 parameters, a keyed array of fields including their enabled
+status and weight, and the post type.
 
 ```php
 add_filter( 'ep_weighting_default_post_type_weights', function ( array $fields, string $post_type ) : array {
-	// Add fields for all post types.
-	$fields['meta.keywords.value'] = [
-		'enabled' => true,
-		'weight' => 1.0,
-	];
+    // Add fields for all post types.
+    $fields['meta.keywords.value'] = [
+        'enabled' => true,
+        'weight' => 1.0,
+    ];
 
-	// Add fields for specific post types.
-	switch ( $post_type ) {
-		case 'attachment':
-			$fields['alt'] = [
-				'enabled' => true,
-				'weight' => 1.5,
-			];
-			break;
-		case 'project':
-			$fields['meta.client.value'] = [
-				'enabled' => true,
-				'weight' => 1.0,
-			];
-			break;
-	}
+    // Add fields for specific post types.
+    switch ( $post_type ) {
+        case 'attachment':
+            $fields['alt'] = [
+                'enabled' => true,
+                'weight' => 1.5,
+            ];
+            break;
+        case 'project':
+            $fields['meta.client.value'] = [
+                'enabled' => true,
+                'weight' => 1.0,
+            ];
+            break;
+    }
 
-	return $fields;
+    return $fields;
 }, 10, 2 );
 ```

--- a/docs/querying/custom-queries.md
+++ b/docs/querying/custom-queries.md
@@ -2,39 +2,43 @@
 title: Custom Queries
 order: 100
 ---
+
 # Custom Queries and Elasticsearch Usage
 
-When working with custom data types or advanced search implementations, you may want to build direct integrations with Elasticsearch, rather than using the higher level features and APIs provided for CMS content.
-
+When working with custom data types or advanced search implementations, you may want to build direct integrations with
+Elasticsearch, rather than using the higher level features and APIs provided for CMS content.
 
 ## Making HTTP Requests
 
-Elasticsearch uses the HTTP protocol for all requests and tasks. You can use the built-in HTTP API to make these requests, or you can use a HTTP client library of your choosing.
+Elasticsearch uses the HTTP protocol for all requests and tasks. You can use the built-in HTTP API to make these requests, or you
+can use a HTTP client library of your choosing.
 
-Use the `Altis\Enhanced_Search\get_elasticsearch_url()` function to retrieve the Elastcisearch cluster endpoint when making your own requests.
+Use the `Altis\Enhanced_Search\get_elasticsearch_url()` function to retrieve the Elasticsearch cluster endpoint when making your own
+requests.
 
-Any requests made to Elasticsearch using the built-in HTTP API functions (`wp_remote_get`, `wp_remote_post`, `wp_remote_request`, etc) will automatically sign requests for the appropriate authentication HTTP headers.
+Any requests made to Elasticsearch using the built-in HTTP API functions (`wp_remote_get`, `wp_remote_post`, `wp_remote_request`,
+etc) will automatically sign requests for the appropriate authentication HTTP headers.
 
 For example, to create an index for a custom data type:
 
 ```php
 $request = wp_remote_request(
-	Altis\Enhanced_Search\get_elasticsearch_url() . '/tweets',
-	[
-		'method' => 'PUT',
-		'headers' => [
-			'Content-Type' => 'application/json',
-		],
-		'body'   => json_encode( [
-			'mappings' => [
-				'_doc' => [
-					'properties' => [
-						'content' => [ 'type' => 'text' ],
-					],
-				],
-			],
-		] ),
-	]
+    Altis\Enhanced_Search\get_elasticsearch_url() . '/tweets',
+    [
+        'method' => 'PUT',
+        'headers' => [
+            'Content-Type' => 'application/json',
+        ],
+        'body'   => json_encode( [
+            'mappings' => [
+                '_doc' => [
+                    'properties' => [
+                        'content' => [ 'type' => 'text' ],
+                    ],
+                ],
+            ],
+        ] ),
+    ]
 );
 
 var_dump( json_decode( wp_remote_retrieve_body( $request ) ) );
@@ -42,7 +46,8 @@ var_dump( json_decode( wp_remote_retrieve_body( $request ) ) );
 
 ## PSR7 HTTP Requests
 
-To sign your own PSR7 requests (if using Guzzle for example) with authentication headers, use the `Altis\Enhanced_Search\sign_psr7_request()` function:
+To sign your own PSR7 requests (if using Guzzle for example) with authentication headers, use
+the `Altis\Enhanced_Search\sign_psr7_request()` function:
 
 ```php
 use GuzzleHttp\Client;


### PR DESCRIPTION
This changes all the docs files to be formatted correctly after linting. The main changes are line length, spaces instead of tabs, and addition of alt text for images. Some grammar and spelling issues were also fixed.

Resolves https://github.com/humanmade/altis-enhanced-search/issues/440