### PR TITLE
Fix ElasticPress warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Import Travis configuration from dev-tools repo
 version: ~> 1.0
 import:
-  - source: humanmade/altis-dev-tools:travis/module.yml@f1fd9a5
+  - source: humanmade/altis-dev-tools:travis/module.yml@0bfa112a
     mode: deep_merge_append

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -821,7 +821,7 @@ function get_elasticsearch_url() : string {
  */
 function setup_elasticpress_on_install() {
 	WP_CLI::line( 'Setting up ElasticPress...' );
-	$response = WP_CLI::runcommand( 'elasticpress index --setup --network-wide --yes', [
+	$response = WP_CLI::runcommand( 'elasticpress sync --setup --network-wide --yes', [
 		'return' => true,
 	] );
 	WP_CLI::line( $response );


### PR DESCRIPTION
Call the CLI command `sync` instead of the deprecated `index` command.