### PR TITLE
Fix memory leak on indexing ES on local / dev / staging

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -213,7 +213,7 @@ function load_elasticpress() {
 	// Set up packages feature.
 	Packages\bootstrap();
 
-	// Hook the reset_elasticsearch_queries function to the ep_stop_the_insanity action
+	// Hook the reset_elasticsearch_queries function to the ep_stop_the_insanity action.
 	add_action( 'ep_stop_the_insanity', __NAMESPACE__ . '\\reset_elasticsearch_queries' );
 }
 
@@ -2208,7 +2208,7 @@ function sanitize_query_args( WP_Query $query ) : void {
  * @return void
  */
 function reset_elasticsearch_queries() {
-	$reflection = new ReflectionProperty(Elasticsearch::class, 'queries');
-	$reflection->setAccessible(true);
-	$reflection->setValue(Elasticsearch::factory(), []);
+	$reflection = new ReflectionProperty( Elasticsearch::class, 'queries' );
+	$reflection->setAccessible( true );
+	$reflection->setValue( Elasticsearch::factory(), [] );
 }


### PR DESCRIPTION
Add a new function `reset_elasticsearch_queries` to handle the logic for resetting the Elasticsearch queries.

* Add `use ReflectionProperty` at the top of the file and ensure all `use` statements are in alphabetical order
* Hook the new function to the `ep_stop_the_insanity` action using `add_action`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/humanmade/altis-enhanced-search/pull/528?shareId=5b511c88-24c0-47f6-a12d-ff53fa14087e).