### PR TITLE
257 document optional containers

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -39,7 +39,7 @@ function bootstrap() {
 	// Allow disabling ElasticPress for local-server and ci environments.
 	$environment = Altis\get_environment_type();
 	if ( isset( Altis\get_config()['environments'][ $environment ]['modules']['cloud']['elasticsearch'] ) &&
-	     ( Altis\get_config()['environments'][ $environment ]['modules']['cloud']['elasticsearch'] === false ) ) {
+		( Altis\get_config()['environments'][ $environment ]['modules']['cloud']['elasticsearch'] === false ) ) {
 		return;
 	}
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -35,8 +35,11 @@ const SORTABLE_MAX_LENGTH = 10922;
  * @return void
  */
 function bootstrap() {
-	if ( isset( Altis\get_config()['modules']['cloud']['elasticsearch'] ) &&
-	     ( Altis\get_config()['modules']['cloud']['elasticsearch'] === false ) ) {
+
+	// Allow disabling ElasticPress for local-server and ci environments.
+	$environment = Altis\get_environment_type();
+	if ( isset( Altis\get_config()['environments'][ $environment ]['modules']['cloud']['elasticsearch'] ) &&
+	     ( Altis\get_config()['environments'][ $environment ]['modules']['cloud']['elasticsearch'] === false ) ) {
 		return;
 	}
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -35,6 +35,11 @@ const SORTABLE_MAX_LENGTH = 10922;
  * @return void
  */
 function bootstrap() {
+	if ( isset( Altis\get_config()['modules']['cloud']['elasticsearch'] ) &&
+	     ( Altis\get_config()['modules']['cloud']['elasticsearch'] === false ) ) {
+		return;
+	}
+
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_elasticpress', 4 );
 	add_action( 'plugins_loaded', function () {
 		// Run healthchecks on indexes after ElasticPress is loaded.


### PR DESCRIPTION
Remove errors when elasticsearch is turned off

When turning off elasticsearch for local server, ensure we don't load elasticpress or try to contact the ES host.

Addresses https://github.com/humanmade/altis-local-server/issues/257