### PR TITLE
Update related posts information

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -38,16 +38,6 @@ The following options can be enabled/disabled via the search configuration.
 - `"terms": true (default)|false`
 - `"comments": true|false (default)`
 
-### Related Posts
-
-To find related posts leveraging Elasticsearch, use the `ep_find_related()` function.
-
-The function requires a single parameter ( `$post_id` ) with another optional parameter ( `$return` ). The `$post_id` will be used
-to find the posts that are related to it, with `$return` specifying the number of related posts to return, which defaults to 5.
-
-If an out of the box solution is desired, the "ElasticPress - Related Posts" widget can be added to your site's sidebar. In order
-for the widget to work correctly it needs to be added to the sidebar which will be displayed for a single post.
-
 ### Facets
 
 Facets are a feature in ElasticPress which add control to filter content by one or more taxonomies. A widget can be added so when

--- a/docs/querying/related-posts.md
+++ b/docs/querying/related-posts.md
@@ -1,0 +1,18 @@
+# Related Posts
+
+To find related posts leveraging Elasticsearch, use the `RelatedPosts::find_related()` function.
+
+The `find_related()` function is used to find related posts based on the content of a given post.
+
+The function requires a single parameter (`$post_id`) with another optional parameter (`$return`). The `$post_id` will be used
+to find the posts that are related to it, with `$return` specifying the number of related posts to return, which defaults to 5.
+
+This function is a registered feature of `ElasticPress` and is invoked as follows:
+
+```php
+\ElasticPress\Features::factory()->get_registered_feature( 'related_posts' )->find_related( $post_id, 3 )
+```
+
+If an out-of-the-box solution is desired, the "ElasticPress - Related Posts" block can be added to your site's sidebar. In
+order for the widget to work correctly it needs to be added to the sidebar which will be displayed for a single post.
+


### PR DESCRIPTION
Update the information to document the new method of finding related posts and remove mention of the deprecated function.

The new information is moved to its own page under the "Querying" subdirectory.

New page:
![CleanShot 2025-05-09 at 12 59 51](https://github.com/user-attachments/assets/f6cfbf6a-c319-4c3c-bb3f-f7dbea8b3eeb)


Fixes https://github.com/humanmade/altis-enhanced-search/issues/445