### PR TITLE
Reindex Elasticsearch on `wp altis post-sync`

### DIFF
--- a/docs/indexing/reindexing.md
+++ b/docs/indexing/reindexing.md
@@ -48,6 +48,16 @@ wp elasticpress sync
 **Note:** During the indexing process, the site will not use the Elasticsearch index for searches/queries, so some features like
 faceting or autosuggest will not work as expected until the process is finished.
 
+### Reindexing after an environment sync
+
+The Search module also hooks into the [`wp altis post-sync`](docs://core/cli-command.md) command, so a network-wide reindex with
+mapping setup runs automatically after you sync an environment (for example, pulling a production database to staging). If you
+prefer to manage reindexing yourself, unhook the default action:
+
+```php
+remove_action( 'altis.post_sync', 'Altis\Enhanced_Search\reindex_elasticsearch' );
+```
+
 ## Recreating Mappings
 
 If your index mapping changes, the mapping will need to be recreated. This may be needed after an Altis upgrade, when adjusting

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -49,6 +49,9 @@ function bootstrap() {
 		add_filter( 'altis_healthchecks', __NAMESPACE__ . '\\add_elasticsearch_healthcheck' );
 	} );
 
+	// Reindex on `wp altis post-sync` (provided by altis/core).
+	add_action( 'altis.post_sync', __NAMESPACE__ . '\\reindex_elasticsearch' );
+
 	// Load debug bar for ElasticPress if Query Monitor is enabled in the config and not a CLI request.
 	if (
 		( Altis\get_config()['modules']['dev-tools']['enabled'] ?? false ) &&
@@ -841,6 +844,25 @@ function setup_elasticpress_on_install() {
 	] );
 	WP_CLI::line( $response );
 	WP_CLI::line( WP_CLI::colorize( '%GElasticPress configured.%n' ) );
+}
+
+/**
+ * Reindex Elasticsearch on `wp altis post-sync`.
+ *
+ * Hooked to the `altis.post_sync` action provided by altis/core. Skips
+ * reindexing if Elasticsearch is not configured for this environment.
+ *
+ * @return void
+ */
+function reindex_elasticsearch() : void {
+	if ( ! defined( 'ELASTICSEARCH_HOST' ) || ! ELASTICSEARCH_HOST ) {
+		WP_CLI::log( 'Elasticsearch not available, skipping reindex.' );
+		return;
+	}
+
+	WP_CLI::log( 'Reindexing Elasticsearch...' );
+	WP_CLI::runcommand( 'elasticpress sync --setup --network-wide --yes' );
+	WP_CLI::success( 'Elasticsearch reindex complete.' );
 }
 
 /**


### PR DESCRIPTION
## Summary

- Hooks `Altis\Enhanced_Search\reindex_elasticsearch` into the `altis.post_sync` action provided by altis/core (humanmade/altis-core#1405), so a network-wide reindex with mapping setup runs automatically after an environment sync.
- The hook is only registered when the Search module is enabled; the function also bails at runtime when `ELASTICSEARCH_HOST` is undefined, matching the existing guard used by `load_elasticpress()`.
- Documents the new behaviour in `docs/indexing/reindexing.md`, including how to unhook the default action.

- Addresses humanmade/altis-core#1298

## Test plan

- [ ] With the Search module enabled and `ELASTICSEARCH_HOST` defined, run `wp altis post-sync` and confirm the reindex runs (`elasticpress sync --setup --network-wide --yes`).
- [ ] With the Search module enabled but `ELASTICSEARCH_HOST` not defined, run `wp altis post-sync` and confirm the reindex is skipped with the "Elasticsearch not available" log line.
- [ ] With the Search module disabled, confirm `wp altis post-sync` runs without attempting a reindex and does not error.
- [ ] Verify the default action can be unhooked: `remove_action( 'altis.post_sync', 'Altis\\Enhanced_Search\\reindex_elasticsearch' );`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)