### PR TITLE
Use wildcard Host matchers instead of HostRegexp

### DIFF
--- a/inc/class-local-server-extension.php
+++ b/inc/class-local-server-extension.php
@@ -129,7 +129,7 @@ class Local_Server_Extension implements Compose_Extension {
 				'labels' => [
 					'traefik.enable=true',
 					'traefik.docker.network=proxy',
-					"traefik.http.routers.{$this->generator->project_name}-elasticsearch.rule=HostRegexp(`elasticsearch-{$this->generator->hostname}`)",
+					"traefik.http.routers.{$this->generator->project_name}-elasticsearch.rule=Host(`elasticsearch-{$this->generator->hostname}`)",
 					"traefik.http.routers.{$this->generator->project_name}-elasticsearch.entrypoints=web,websecure",
 					"traefik.http.routers.{$this->generator->project_name}-elasticsearch.service={$this->generator->project_name}-elasticsearch",
 					"traefik.http.services.{$this->generator->project_name}-elasticsearch.loadbalancer.server.port=9200",
@@ -183,7 +183,7 @@ class Local_Server_Extension implements Compose_Extension {
 				'labels' => [
 					'traefik.enable=true',
 					'traefik.docker.network=proxy',
-					'traefik.http.routers.' . $this->generator->project_name . '-kibana.rule=(Host(`' . $this->generator->hostname . '`) || HostRegexp(`^[A-Za-z0-9-]+\\.' . str_replace( '.', '\\.', $this->generator->hostname ) . '$`)) && PathPrefix(`/kibana`)',
+					"traefik.http.routers.{$this->generator->project_name}-kibana.rule=(Host(`{$this->generator->hostname}`) || Host(`*.{$this->generator->hostname}`)) && PathPrefix(`/kibana`)",
 					"traefik.http.routers.{$this->generator->project_name}-kibana.entrypoints=web,websecure",
 					"traefik.http.routers.{$this->generator->project_name}-kibana.service={$this->generator->project_name}-kibana",
 					"traefik.http.services.{$this->generator->project_name}-kibana.loadbalancer.server.port=5601",


### PR DESCRIPTION
## Summary

Replaces the two `HostRegexp` Traefik route rules in `Local_Server_Extension` with the new wildcard `Host` matcher introduced in Traefik 3.7:

- **elasticsearch router** (line 132): `HostRegexp(\`elasticsearch-<host>\`)` → `Host(\`elasticsearch-<host>\`)`. The rule never had any regex metacharacters; this just drops the unnecessary regex matcher.
- **kibana router** (line 186): the subdomain branch of the alternation goes from `HostRegexp(\`^[A-Za-z0-9-]+\.<host>$\`)` to `Host(\`*.<host>\`)`. The literal `Host(\`<host>\`)` branch is unchanged.

Why:

- Simpler, cheaper matcher (no regex compile).
- TLSOptions can be associated with wildcard `Host` matchers, but **not** with `HostRegexp` (per the 3.7 migration notes). This unblocks per-domain TLS options in the future.

Behavior note: wildcard `Host(\`*.<host>\`)` matches any DNS-valid single-level subdomain, while the old regex restricted labels to `[A-Za-z0-9-]+`. For local dev this is a deliberate relaxation. Two-level subdomains (e.g. `a.b.<host>`) do *not* match, matching the prior regex behavior.

## Dependencies

Requires Traefik ≥ 3.7. Pair with [humanmade/altis-local-server#932](https://github.com/humanmade/altis-local-server/pull/932) (proxy image bump). The companion wildcard refactor in local-server is [#933](https://github.com/humanmade/altis-local-server/pull/933).

## Test plan

Verified locally with the proxy on `traefik:3.7.1`:

- [x] `https://elasticsearch-<host>/` returns 200 (ES cluster root)
- [x] `https://<host>/kibana` returns 302 (primary host branch)
- [x] `https://test-sub.<host>/kibana` returns 302 (wildcard branch)
- [x] `https://a.b.<host>/kibana` returns 404 (two-level subdomain correctly does NOT match)
- [x] Full `enhanced-search` acceptance suite passes (6 tests pass, 1 incomplete on purpose — Autosuggest). The reindex calls in those tests hit the `elasticsearch-<host>` route end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)