### PR TITLE
Fix debug-bar-elasticpress load priority to avoid missing query-monitor dep

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -62,7 +62,7 @@ function bootstrap() {
 		if ( ! defined( 'WP_EP_DEBUG' ) ) {
 			define( 'WP_EP_DEBUG', true );
 		}
-		add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_debug_bar_elasticpress', 0 );
+		add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_debug_bar_elasticpress', 20 );
 	}
 }
 


### PR DESCRIPTION
## Summary

- `debug-bar-elasticpress` was hooked to `plugins_loaded` at priority 0, before query-monitor has registered its script handle
- This produces a PHP notice: `The script/style with handle "debug-bar-elasticpress" was enqueued with dependencies that are not registered: query-monitor`
- Changing the priority from 0 to 20 ensures QM is set up first while still running well within `plugins_loaded`

## Test plan

- [x] Load any admin page with `WP_EP_DEBUG` enabled and QM active
- [x] Confirm the "dependency not registered: query-monitor" notice is gone from PHP logs

Discovered during WP 7.0 QA (humanmade/product-dev#2127).