### PR TITLE
Spike: analyzer fix on v24-branch (investigation, do not merge)

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -1110,15 +1110,18 @@ function elasticpress_mapping( array $mapping, ?string $index = null ) : array {
 		);
 	}
 
+	// Always ensure default_search analyzer matches default analyzer to prevent stemming mismatch.
+	// ElasticPress 5.x defines its own default_search with aggressive snowball stemming which
+	// doesn't match the light stemming used in the default analyzer, causing search failures.
+	// See: https://github.com/10up/ElasticPress/issues/4249
+	$mapping['settings']['analysis']['analyzer']['default_search'] = $mapping['settings']['analysis']['analyzer']['default'];
+
 	if ( ! empty( $synonyms ) || ! empty( $stopwords ) ) {
 		$mapping['settings']['analysis']['filter'] = array_merge(
 			$mapping['settings']['analysis']['filter'],
 			$synonyms,
 			$stopwords
 		);
-
-		// Copy default analyzer to default search.
-		$mapping['settings']['analysis']['analyzer']['default_search'] = $mapping['settings']['analysis']['analyzer']['default'];
 
 		// Add stopwords after `icu_normalizer` if present, otherwise prepend.
 		// This ensures text is lowercased and full-width characters converted to


### PR DESCRIPTION
Investigation only — triggers module CI to test whether backporting c37d94970 affects the ElasticSearchCest synonym/stopword failures on EP 4.7. The fix targets EP 5.x stemming, so it's expected to be inert here; this run tells us the baseline (2-fail vs all-fail) on the canonical harness. No reviewers by design.