### PR TITLE
Add regression test for the Debug Bar ElasticPress asset dependencies

### DIFF
--- a/tests/integration.suite.yml
+++ b/tests/integration.suite.yml
@@ -1,0 +1,9 @@
+# Codeception Test Suite Configuration
+#
+# Suite for unit or integration tests that require WordPress functions and classes.
+
+actor: IntegrationTester
+modules:
+    enabled:
+        - WPLoader
+        - \Helper\Integration

--- a/tests/integration/debug-bar/DebugBarAssetDepsTest.php
+++ b/tests/integration/debug-bar/DebugBarAssetDepsTest.php
@@ -83,12 +83,23 @@ class DebugBarAssetDepsTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * Build the panel.
 	 *
+	 * Loading the plugin only hooks its `debug_bar_panels` callback -- the panel
+	 * class itself is required from inside that callback, so it doesn't exist
+	 * until the filter runs. Go through the filter, the same way Query Monitor
+	 * does, rather than requiring the class file directly.
+	 *
 	 * @return \EP_Debug_Bar_ElasticPress
 	 */
 	protected function get_panel() {
 		\Altis\Enhanced_Search\load_debug_bar_elasticpress();
 
-		return new \EP_Debug_Bar_ElasticPress();
+		foreach ( apply_filters( 'debug_bar_panels', [] ) as $panel ) {
+			if ( $panel instanceof \EP_Debug_Bar_ElasticPress ) {
+				return $panel;
+			}
+		}
+
+		$this->fail( 'The ElasticPress panel was not registered on the debug_bar_panels filter.' );
 	}
 
 	/**

--- a/tests/integration/debug-bar/DebugBarAssetDepsTest.php
+++ b/tests/integration/debug-bar/DebugBarAssetDepsTest.php
@@ -25,11 +25,29 @@ class DebugBarAssetDepsTest extends \Codeception\TestCase\WPTestCase {
 	protected $tester;
 
 	/**
-	 * Reset the dependency registries before each test.
+	 * The style registry in place before this test replaced it.
+	 *
+	 * @var \WP_Styles|null
+	 */
+	private $old_wp_styles;
+
+	/**
+	 * The script registry in place before this test replaced it.
+	 *
+	 * @var \WP_Scripts|null
+	 */
+	private $old_wp_scripts;
+
+	/**
+	 * Swap in clean dependency registries for each test.
 	 *
 	 * WP_Dependencies dedupes its missing-dependency notice per handle per
 	 * instance, so a shared $wp_styles would make the second test here pass for
 	 * the wrong reason. Start each test from a clean instance.
+	 *
+	 * Mirrors WordPress core's own approach in Tests_Dependencies_Styles: the
+	 * test framework does not back these globals up, so they are restored in
+	 * tear_down() to avoid leaking empty registries into later tests.
 	 *
 	 * @return void
 	 */
@@ -40,8 +58,26 @@ class DebugBarAssetDepsTest extends \Codeception\TestCase\WPTestCase {
 			$this->markTestSkipped( 'Requires the dev-tools module with Query Monitor enabled.' );
 		}
 
+		$this->old_wp_styles = $GLOBALS['wp_styles'] ?? null;
+		$this->old_wp_scripts = $GLOBALS['wp_scripts'] ?? null;
+
 		$GLOBALS['wp_styles'] = new \WP_Styles();
+		$GLOBALS['wp_styles']->default_version = get_bloginfo( 'version' );
+
 		$GLOBALS['wp_scripts'] = new \WP_Scripts();
+		$GLOBALS['wp_scripts']->default_version = get_bloginfo( 'version' );
+	}
+
+	/**
+	 * Put the original dependency registries back.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		$GLOBALS['wp_styles'] = $this->old_wp_styles;
+		$GLOBALS['wp_scripts'] = $this->old_wp_scripts;
+
+		parent::tear_down();
 	}
 
 	/**
@@ -65,6 +101,9 @@ class DebugBarAssetDepsTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->get_panel()->enqueue_scripts_styles();
 
+		$this->assertArrayHasKey( 'debug-bar-elasticpress', wp_styles()->registered, 'The style should be registered.' );
+		$this->assertArrayHasKey( 'debug-bar-elasticpress', wp_scripts()->registered, 'The script should be registered.' );
+
 		$this->assertNotContains( 'query-monitor', wp_styles()->registered['debug-bar-elasticpress']->deps );
 		$this->assertNotContains( 'query-monitor', wp_scripts()->registered['debug-bar-elasticpress']->deps );
 	}
@@ -82,6 +121,9 @@ class DebugBarAssetDepsTest extends \Codeception\TestCase\WPTestCase {
 		wp_register_script( 'query-monitor', 'https://example.com/qm.js', [], '1.0', false );
 
 		$this->get_panel()->enqueue_scripts_styles();
+
+		$this->assertArrayHasKey( 'debug-bar-elasticpress', wp_styles()->registered, 'The style should be registered.' );
+		$this->assertArrayHasKey( 'debug-bar-elasticpress', wp_scripts()->registered, 'The script should be registered.' );
 
 		$this->assertContains( 'query-monitor', wp_styles()->registered['debug-bar-elasticpress']->deps );
 		$this->assertContains( 'query-monitor', wp_scripts()->registered['debug-bar-elasticpress']->deps );

--- a/tests/integration/debug-bar/DebugBarAssetDepsTest.php
+++ b/tests/integration/debug-bar/DebugBarAssetDepsTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Test the Debug Bar ElasticPress panel's asset dependencies.
+ *
+ * phpcs:disable WordPress.Files, HM.Files, HM.Functions.NamespacedFunctions, WordPress.NamingConventions
+ */
+
+namespace DebugBar;
+
+/**
+ * Test the Debug Bar ElasticPress panel's asset dependencies.
+ *
+ * The panel is constructed on every request, but Query Monitor only registers
+ * its `query-monitor` script and style handles when its HTML dispatcher will
+ * actually render. Enqueuing against a handle that was never registered emits
+ * a _doing_it_wrong() notice from WP_Dependencies::all_deps() in WordPress
+ * 6.9.1+, so the panel has to declare that dependency conditionally.
+ */
+class DebugBarAssetDepsTest extends \Codeception\TestCase\WPTestCase {
+	/**
+	 * Tester
+	 *
+	 * @var \IntegrationTester
+	 */
+	protected $tester;
+
+	/**
+	 * Reset the dependency registries before each test.
+	 *
+	 * WP_Dependencies dedupes its missing-dependency notice per handle per
+	 * instance, so a shared $wp_styles would make the second test here pass for
+	 * the wrong reason. Start each test from a clean instance.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		if ( ! class_exists( 'Debug_Bar_Panel' ) ) {
+			$this->markTestSkipped( 'Requires the dev-tools module with Query Monitor enabled.' );
+		}
+
+		$GLOBALS['wp_styles'] = new \WP_Styles();
+		$GLOBALS['wp_scripts'] = new \WP_Scripts();
+	}
+
+	/**
+	 * Build the panel.
+	 *
+	 * @return \EP_Debug_Bar_ElasticPress
+	 */
+	protected function get_panel() {
+		\Altis\Enhanced_Search\load_debug_bar_elasticpress();
+
+		return new \EP_Debug_Bar_ElasticPress();
+	}
+
+	/**
+	 * The panel must not depend on `query-monitor` when it isn't registered.
+	 *
+	 * @return void
+	 */
+	public function testNoQueryMonitorDependencyWhenUnregistered() {
+		$this->assertFalse( wp_style_is( 'query-monitor', 'registered' ), 'Precondition: query-monitor is not registered.' );
+
+		$this->get_panel()->enqueue_scripts_styles();
+
+		$this->assertNotContains( 'query-monitor', wp_styles()->registered['debug-bar-elasticpress']->deps );
+		$this->assertNotContains( 'query-monitor', wp_scripts()->registered['debug-bar-elasticpress']->deps );
+	}
+
+	/**
+	 * The panel must still depend on `query-monitor` when it is registered.
+	 *
+	 * Guards against over-correcting: the dependency is what keeps the panel
+	 * styles loading after Query Monitor's own.
+	 *
+	 * @return void
+	 */
+	public function testQueryMonitorDependencyWhenRegistered() {
+		wp_register_style( 'query-monitor', 'https://example.com/qm.css', [], '1.0' );
+		wp_register_script( 'query-monitor', 'https://example.com/qm.js', [], '1.0', false );
+
+		$this->get_panel()->enqueue_scripts_styles();
+
+		$this->assertContains( 'query-monitor', wp_styles()->registered['debug-bar-elasticpress']->deps );
+		$this->assertContains( 'query-monitor', wp_scripts()->registered['debug-bar-elasticpress']->deps );
+	}
+
+	/**
+	 * Printing the panel's assets must not raise a doing_it_wrong notice.
+	 *
+	 * WP_UnitTestCase fails the test on any unexpected _doing_it_wrong(), which
+	 * is precisely the notice this guards against.
+	 *
+	 * @return void
+	 */
+	public function testPrintingAssetsRaisesNoNotice() {
+		$this->get_panel()->enqueue_scripts_styles();
+
+		ob_start();
+		wp_styles()->do_items();
+		wp_scripts()->do_items();
+		ob_end_clean();
+
+		$this->assertTrue( wp_style_is( 'debug-bar-elasticpress', 'done' ) );
+	}
+}


### PR DESCRIPTION
- https://github.com/humanmade/debug-bar-elasticpress/pull/9 must be merged first and 1.6.4 tag must be added also before merging this.
- Asserts on the registered deps array rather than on notice emission: WP_Dependencies dedupes that notice per handle per instance, so a shared $wp_styles would let a later test pass for the wrong reason. set_up() gives each test a fresh WP_Styles/WP_Scripts for the same reason.
- The second case asserts the dependency IS declared when query-monitor is registered, so we don't over-correct and break the load order.

Addresses humanmade/product-dev#2269